### PR TITLE
Fixing NuGet reference HintPaths and inconsistent versions

### DIFF
--- a/Arriba/Arriba.IIS/Arriba.IIS.csproj
+++ b/Arriba/Arriba.IIS/Arriba.IIS.csproj
@@ -79,7 +79,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Owin">
-      <HintPath>..\nuget-packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions">

--- a/Arriba/Arriba.Server/Arriba.Server.csproj
+++ b/Arriba/Arriba.Server/Arriba.Server.csproj
@@ -125,9 +125,9 @@
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.14.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\nuget-packages\Microsoft.Tpl.Dataflow.4.5.14\lib\portable-net45+win8\System.Threading.Tasks.Dataflow.dll</HintPath>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Cors">

--- a/Arriba/Arriba.Server/packages.config
+++ b/Arriba/Arriba.Server/packages.config
@@ -11,7 +11,7 @@
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.SelfHost" version="2.1.0-rc1" targetFramework="net45" />
-  <package id="Microsoft.Tpl.Dataflow" version="4.5.14" targetFramework="net45" />
+  <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fixing NuGet reference HintPaths which were wrong (causing failed first build) and making System.Threading.Tasks.Dataflow references consistent (fix inconsistent dependency versions warning).