### PR TITLE
Changes to Elfie for new scenario use.

### DIFF
--- a/Elfie/Elfie/Model/Strings/String8.cs
+++ b/Elfie/Elfie/Model/Strings/String8.cs
@@ -7,6 +7,7 @@ using System.Text;
 
 using Microsoft.CodeAnalysis.Elfie.Extensions;
 using Microsoft.CodeAnalysis.Elfie.Serialization;
+using Microsoft.CodeAnalysis.Elfie.Model.Structures;
 
 namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
 {
@@ -19,11 +20,11 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
     /// </summary>
     public struct String8 : IComparable<String8>, IComparable<string>, IBinarySerializable, IWriteableString
     {
-        private byte[] _buffer;
-        private int _index;
-        private int _length;
+        internal byte[] _buffer;
+        internal int _index;
+        internal int _length;
 
-        internal String8(byte[] buffer, int index, int length)
+        public String8(byte[] buffer, int index, int length)
         {
             _buffer = buffer;
             _index = index;
@@ -88,6 +89,20 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
         public String8Set Split(char delimiter, int[] positionArray)
         {
             return String8Set.Split(this, delimiter, positionArray);
+        }
+
+        /// <summary>
+        ///  Split this String8 into a String8Set with the given delimiter.
+        ///  Requires the caller to pass an int[] to contain the split positions.
+        ///  Reuse the array in a loop for much better performance. Call
+        ///  String8Set.GetLength to determine the array length required.
+        /// </summary>
+        /// <param name="delimiter">Delimiter on which to split</param>
+        /// <param name="positions">PartialArray&lt;int&gt; to contain split positions</param>
+        /// <returns>String8Set containing the String8 split on the delimiter</returns>
+        public String8Set Split(char delimiter, PartialArray<int> positions)
+        {
+            return String8Set.Split(this, delimiter, positions);
         }
 
         /// <summary>

--- a/Elfie/Elfie/Model/Structures/PartialArray.cs
+++ b/Elfie/Elfie/Model/Structures/PartialArray.cs
@@ -77,6 +77,12 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Structures
             System.Array.Sort<T>(_array, 0, this.Count, comparer);
         }
 
+        public static void SortKeysAndItems<U, V>(PartialArray<U> keys, PartialArray<V> items)
+        {
+            if (keys.Count != items.Count) throw new InvalidOperationException("Can't sort key and item arrays of different lengths.");
+            Array.Sort(keys._array, items._array, 0, keys.Count);
+        }
+
         public int Capacity
         {
             get


### PR DESCRIPTION
Code Review Ryley, in person.
- Exposing String8 members for String8Set use.
- String8Set.Split 3x speedup (direct use of byte[]).
- Allow creating a String8 directly from a byte[], index, length.
- Allow passing PartialArrays to String8Set.Split so that you can allocate one without knowing how big and reuse it across splits.