### PR TITLE
Arriba CSV Import Fixes

### DIFF
--- a/Arriba/Arriba/Model/Table.cs
+++ b/Arriba/Arriba/Model/Table.cs
@@ -329,6 +329,9 @@ namespace Arriba.Model
                     bestColumnType = Value.Create(values[rowIndex, columnIndex]).BestType(bestColumnType);
                 }
 
+                // If no values were set, default to string [can't tell actual best type]
+                if (bestColumnType == null) bestColumnType = typeof(String);
+
                 discoveredNewColumns.Add(new ColumnDetails(columnName, bestColumnType.Name, null) { IsPrimaryKey = isIdColumn });
                 foundIdColumn |= isIdColumn;
             }


### PR DESCRIPTION
- Fix to default column type to string if no values were set in first block.
- Arriba.Csv: Respect item count. Add "add" mode to add values from CSV to existing table. Allow adding columns during add mode.