### PR TITLE
Elfie TsvWriter, Arriba AddOrUpdate options

### DIFF
--- a/Arriba/Arriba.Test/Model/Correctors/ExpressionCorrectorTests.cs
+++ b/Arriba/Arriba.Test/Model/Correctors/ExpressionCorrectorTests.cs
@@ -77,7 +77,7 @@ namespace Arriba.Test.Model.Correctors
                 }
             );
 
-            people.AddOrUpdate(block);
+            people.AddOrUpdate(block, new AddOrUpdateOptions() { AddMissingColumns = true });
 
             UserAliasCorrector corrector = new UserAliasCorrector(people);
 

--- a/Arriba/Arriba.Test/Model/TableTests.cs
+++ b/Arriba/Arriba.Test/Model/TableTests.cs
@@ -90,7 +90,7 @@ namespace Arriba.Test.Model
             DataBlock block = BuildSampleData();
             int[] partitionChains = new int[] { 1, -1, 3, 4, -1 };
             int[] partitionChainHeads = new int[] { 0, 2 };
-            p.AddOrUpdate(block, partitionChains, partitionChainHeads[1]);
+            p.AddOrUpdate(block, new AddOrUpdateOptions(), partitionChains, partitionChainHeads[1]);
 
             // Verify only the right items were added
             SelectQuery q = new SelectQuery();
@@ -156,6 +156,29 @@ namespace Arriba.Test.Model
         }
 
         [TestMethod]
+        public void Table_AddOrUpdate_NoAddRows()
+        {
+            Table t = new Table("Sample", 50000);
+            t.AddOrUpdate(BuildSampleData());
+
+            // Add one new item and update an item
+            DataBlock newData = new DataBlock(new string[] { "ID", "Title" }, 2,
+                new Array[]
+                {
+                    new int[] { 11512, 12345, 12346 },
+                    new string[] { "Existing Item", "New Item", "New Item" }
+                });
+
+            // Ask Arriba not to add new items. Verify no items added, existing item updated
+            t.AddOrUpdate(newData, new AddOrUpdateOptions() { AddMissingRows = false });
+            Assert.AreEqual(5, (int)t.Count);
+
+            SelectQuery q = new SelectQuery() { Columns = new string[] { "Title" }, Count = 10, Where = SelectQuery.ParseWhere("ID = 11512") };
+            SelectResult result = t.Select(q);
+            Assert.AreEqual("Existing Item", result.Values[0, 0].ToString());
+        }
+
+        [TestMethod]
         public void Table_DynamicColumnCreation()
         {
             Table t = new Table("Sample", 50000);
@@ -193,6 +216,30 @@ namespace Arriba.Test.Model
 
             // Verify add didn't partially happen
             Assert.AreEqual(5, (int)t.Count);
+
+            // Build more data and a new column
+            DataBlock newData = new DataBlock(new string[] { "ID", "Resolution" }, 2,
+                new Array[]
+                {
+                    new int[] { 12345, 12346 },
+                    new string[] { "Fixed", "Won't Fix" }
+                });
+
+            // Verify default AddOrUpdate won't add columns again
+            try
+            {
+                t.AddOrUpdate(newData);
+                Assert.Fail("AddOrUpdate shouldn't add columns after the first insert.");
+            }
+            catch(ArribaException)
+            {
+                // Expected - columns are only added on the first insert
+            }
+
+            // Verify AddOrUpdate with option set will add the new column
+            t.AddOrUpdate(newData, new AddOrUpdateOptions() { AddMissingColumns = true });
+
+            Assert.AreEqual(7, (int)t.Count);
         }
 
         [TestMethod]
@@ -412,7 +459,7 @@ namespace Arriba.Test.Model
             // Update an item and verify it
             DataBlock updateItems = new DataBlock(new string[] { "ID", "Priority" }, 1);
             updateItems.SetRow(0, new object[] { 11643, 2 });
-            table.AddOrUpdate(updateItems);
+            table.AddOrUpdate(updateItems, new AddOrUpdateOptions());
             result = table.Select(query);
             Assert.AreEqual(1, (int)result.Total);
             Assert.AreEqual("11999", result.Values[0, 0].ToString());
@@ -779,7 +826,7 @@ Title:unused, null
             items.SetRow(2, new object[] { 1, "Newly Added - should be modified", 99999, false, 3 });
             items.SetRow(3, new object[] { 2, "Modified Added", 99999, false, 3 });
 
-            table.AddOrUpdate(items);
+            table.AddOrUpdate(items, new AddOrUpdateOptions());
 
             SelectQuery query = new SelectQuery();
             query.Columns = new string[] { "ID", "Priority", "Title" };
@@ -837,7 +884,7 @@ Title:unused, null
             // Verify column knows the new default
             DataBlock items = new DataBlock(new string[] { "ID" }, 1);
             items[0, 0] = 12345;
-            table.AddOrUpdate(items);
+            table.AddOrUpdate(items, new AddOrUpdateOptions());
 
             query = new SelectQuery(query.Columns, "ID = 12345");
             result = table.Select(query);
@@ -884,7 +931,7 @@ Title:unused, null
 
             // Add some sample data (with ID column NOT first)
             DataBlock items = BuildSampleData();
-            table.AddOrUpdate(items);
+            table.AddOrUpdate(items, new AddOrUpdateOptions());
         }
 
         private static T FindColumnComponent<T>(IColumn column)

--- a/Arriba/Arriba.Test/Model/TableTests.cs
+++ b/Arriba/Arriba.Test/Model/TableTests.cs
@@ -169,13 +169,16 @@ namespace Arriba.Test.Model
                     new string[] { "Existing Item", "New Item", "New Item" }
                 });
 
-            // Ask Arriba not to add new items. Verify no items added, existing item updated
-            t.AddOrUpdate(newData, new AddOrUpdateOptions() { AddMissingRows = false });
+            // Ask Arriba to ignore new items. Verify no items added, existing item updated
+            t.AddOrUpdate(newData, new AddOrUpdateOptions() { Mode = AddOrUpdateMode.UpdateAndIgnoreAdds });
             Assert.AreEqual(5, (int)t.Count);
 
             SelectQuery q = new SelectQuery() { Columns = new string[] { "Title" }, Count = 10, Where = SelectQuery.ParseWhere("ID = 11512") };
             SelectResult result = t.Select(q);
             Assert.AreEqual("Existing Item", result.Values[0, 0].ToString());
+
+            // Ask Arriba to not add items. Verify exception trying to add a new item.
+            Verify.Exception<ArribaWriteException>(() => t.AddOrUpdate(newData, new AddOrUpdateOptions() { Mode = AddOrUpdateMode.UpdateOnly }));
         }
 
         [TestMethod]

--- a/Arriba/Arriba/Arriba.csproj
+++ b/Arriba/Arriba/Arriba.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="FileLock.cs" />
     <Compile Include="Indexing\IWordSplitter.cs" />
+    <Compile Include="Model\AddOrUpdateOptions.cs" />
     <Compile Include="Model\Column\BooleanColumn.cs" />
     <Compile Include="Model\Column\ColumnDetails.cs" />
     <Compile Include="Model\Column\FastAddSortedColumn.cs" />

--- a/Arriba/Arriba/Model/AddOrUpdateOptions.cs
+++ b/Arriba/Arriba/Model/AddOrUpdateOptions.cs
@@ -1,13 +1,40 @@
 ﻿namespace Arriba.Model
 {
+    /// <summary>
+    ///  AddOrUpdate mode determines how AddOrUpdate handles items
+    ///  with IDs not already in the table.
+    ///   - AddOrUpdate adds rows for new IDs
+    ///   - UpdateOnly throws for new IDs
+    ///   - UpdateAndIgnoreAdds skips items with new IDs
+    /// </summary>
+    public enum AddOrUpdateMode : byte
+    {
+        AddOrUpdate = 0,
+        UpdateOnly = 1,
+        UpdateAndIgnoreAdds = 2
+    }
+
+    /// <summary>
+    ///  AddOrUpdateOptions is used to control the behavior of Table.AddOrUpdate.
+    /// </summary>
     public class AddOrUpdateOptions
     {
-        public bool AddMissingRows { get; set; }
+        /// <summary>
+        ///  Mode determines what to do with items with new IDs.
+        ///  By default, rows are added for items with new IDs.
+        /// </summary>
+        public AddOrUpdateMode Mode { get; set; }
+
+        /// <summary>
+        ///  AddMissingColumns determines whether to add columns not seen before
+        ///  or throw an exception if a new column name is passed.
+        ///  By default, columns are added only to empty tables (on the first insert).
+        /// </summary>
         public bool AddMissingColumns { get; set; }
 
         public AddOrUpdateOptions()
         {
-            this.AddMissingRows = true;
+            this.Mode = AddOrUpdateMode.AddOrUpdate;
             this.AddMissingColumns = false;
         }
     }

--- a/Arriba/Arriba/Model/AddOrUpdateOptions.cs
+++ b/Arriba/Arriba/Model/AddOrUpdateOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace Arriba.Model
+{
+    public class AddOrUpdateOptions
+    {
+        public bool AddMissingRows { get; set; }
+        public bool AddMissingColumns { get; set; }
+
+        public AddOrUpdateOptions()
+        {
+            this.AddMissingRows = true;
+            this.AddMissingColumns = false;
+        }
+    }
+}

--- a/Arriba/Arriba/Model/AddOrUpdateOptions.cs
+++ b/Arriba/Arriba/Model/AddOrUpdateOptions.cs
@@ -28,7 +28,7 @@
         /// <summary>
         ///  AddMissingColumns determines whether to add columns not seen before
         ///  or throw an exception if a new column name is passed.
-        ///  By default, columns are added only to empty tables (on the first insert).
+        ///  By default, columns are not added automatically.
         /// </summary>
         public bool AddMissingColumns { get; set; }
 

--- a/Arriba/Arriba/Model/ITable.cs
+++ b/Arriba/Arriba/Model/ITable.cs
@@ -59,7 +59,7 @@ namespace Arriba.Model
         ///  For each item, the value for each column is set to the provided values.
         /// </summary>
         /// <param name="values">Set of Columns and values to add or update</param>
-        void AddOrUpdate(DataBlock values);
+        void AddOrUpdate(DataBlock values, AddOrUpdateOptions options);
 
         /// <summary>
         ///  Delete items from this Table which meet the provided criteria.

--- a/Arriba/Arriba/Model/Partition.cs
+++ b/Arriba/Arriba/Model/Partition.cs
@@ -217,7 +217,7 @@ namespace Arriba.Model
         ///  For each item, the value for each column is set to the provided values.
         /// </summary>
         /// <param name="values">Set of Columns and values to add or update</param>
-        public void AddOrUpdate(DataBlock values)
+        public void AddOrUpdate(DataBlock values, AddOrUpdateOptions options)
         {
             if (values == null) throw new ArgumentNullException("values");
 
@@ -235,7 +235,7 @@ namespace Arriba.Model
             // Terminate on the final item.
             partitionChains[values.RowCount - 1] = -1;
 
-            AddOrUpdate(values, partitionChains, 0);
+            AddOrUpdate(values, options, partitionChains, 0);
         }
 
         /// <summary>
@@ -246,7 +246,7 @@ namespace Arriba.Model
         /// <param name="partitionChains">storage for the set of linked lists indicating which values are in each partition.  The index is the row number in values
         /// of the corresponding item.  The value is the next item in the chain with -1 indicating the end.</param>
         /// <param name="chainHead">starting index for the list of items that this partition should add</param>
-        public void AddOrUpdate(DataBlock values, int[] partitionChains, int chainStartIndex)
+        public void AddOrUpdate(DataBlock values, AddOrUpdateOptions options, int[] partitionChains, int chainStartIndex)
         {
             if (values == null) throw new ArgumentNullException("values");
             if (partitionChains == null) throw new ArgumentNullException("partitionChains");
@@ -266,7 +266,7 @@ namespace Arriba.Model
             }
 
             // Look up the LID for each item or add it
-            ushort[] itemLIDs = FindOrAssignLIDs(values, partitionChains, chainStartIndex, rowCount, idColumnIndex);
+            ushort[] itemLIDs = FindOrAssignLIDs(values, partitionChains, chainStartIndex, rowCount, idColumnIndex, options.AddMissingRows);
 
             // If there are new items, resize every column for them
             ushort newCount = (ushort)(_itemCount);
@@ -288,7 +288,7 @@ namespace Arriba.Model
             }
         }
 
-        private ushort[] FindOrAssignLIDs(DataBlock values, int[] partitionChains, int startingIndex, int count, int idColumnIndex)
+        private ushort[] FindOrAssignLIDs(DataBlock values, int[] partitionChains, int startingIndex, int count, int idColumnIndex, bool addItems)
         {
             Array idColumnData = values.GetColumn(idColumnIndex);
             Type idColumnDataType = idColumnData.GetType().GetElementType();
@@ -297,7 +297,7 @@ namespace Arriba.Model
             // to the column array.  If the types do not match, we need to fallback to object to allow the Value class to handle the type conversion
             ITypedAddOrUpdateWorker worker = NativeContainer.CreateTypedInstance<ITypedAddOrUpdateWorker>(typeof(AddOrUpdateWorker<>), idColumnDataType);
 
-            return worker.FindOrAssignLIDs(this, idColumnData, partitionChains, startingIndex, count);
+            return worker.FindOrAssignLIDs(this, idColumnData, partitionChains, startingIndex, count, addItems);
         }
 
         private void FillPartitionColumn(DataBlock values, int columnIndex, int[] partitionChains, int chainStartIndex, int rowCount, ushort[] itemLIDs)
@@ -318,7 +318,7 @@ namespace Arriba.Model
 
         private interface ITypedAddOrUpdateWorker
         {
-            ushort[] FindOrAssignLIDs(Partition p, Array idColumnValues, int[] partitionChains, int startingIndex, int count);
+            ushort[] FindOrAssignLIDs(Partition p, Array idColumnValues, int[] partitionChains, int startingIndex, int count, bool addItems);
             void FillPartitionColumn(Partition p, DataBlock values, int columnIndex, int[] partitionChains, int chainStartIndex, int rowCount, ushort[] itemLIDs);
         }
 
@@ -328,7 +328,7 @@ namespace Arriba.Model
         /// <typeparam name="T">Type of the column array</typeparam>
         private class AddOrUpdateWorker<T> : ITypedAddOrUpdateWorker
         {
-            public ushort[] FindOrAssignLIDs(Partition p, Array idColumnValues, int[] partitionChains, int startingIndex, int count)
+            public ushort[] FindOrAssignLIDs(Partition p, Array idColumnValues, int[] partitionChains, int startingIndex, int count, bool addItems)
             {
                 // TODO: consider keeping one instance of the worker long term? if so, this becomes a private class field
                 ValueTypeReference<T> vtr = new ValueTypeReference<T>();
@@ -376,52 +376,55 @@ namespace Arriba.Model
                 }
 
                 // Go back and add the items which need to be added in a batch
-                Dictionary<T, ushort> newlyAssignedLIDs = null;
-
-                for (int i = 0, sourceItemIndex = startingIndex; i < count; ++i, sourceItemIndex = partitionChains[sourceItemIndex])
+                if (addItems)
                 {
-                    ushort lid = itemLIDs[i];
+                    Dictionary<T, ushort> newlyAssignedLIDs = null;
 
-                    // If this is an add...
-                    if (lid == ushort.MaxValue)
+                    for (int i = 0, sourceItemIndex = startingIndex; i < count; ++i, sourceItemIndex = partitionChains[sourceItemIndex])
                     {
-                        // If we have adds, we'll need to track new IDs
-                        if (newlyAssignedLIDs == null) newlyAssignedLIDs = new Dictionary<T, ushort>(addCount);
+                        ushort lid = itemLIDs[i];
 
-                        T externalID = idColumnData[sourceItemIndex];
-
-                        // If this ID was already added in this batch, this time it's an update
-                        if (newlyAssignedLIDs.TryGetValue(externalID, out lid) == false)
+                        // If this is an add...
+                        if (lid == ushort.MaxValue)
                         {
-                            // If this was a new item and not added in this batch, assign it a LID
-                            lid = p._itemCount;
+                            // If we have adds, we'll need to track new IDs
+                            if (newlyAssignedLIDs == null) newlyAssignedLIDs = new Dictionary<T, ushort>(addCount);
 
-                            if (lid == ushort.MaxValue)
+                            T externalID = idColumnData[sourceItemIndex];
+
+                            // If this ID was already added in this batch, this time it's an update
+                            if (newlyAssignedLIDs.TryGetValue(externalID, out lid) == false)
                             {
-                                throw new ArribaWriteException(externalID, p.IDColumn.Name, externalID, new ArribaException("Column full in Partition. Unable to add items."));
-                            }
+                                // If this was a new item and not added in this batch, assign it a LID
+                                lid = p._itemCount;
 
-                            p._itemCount++;
-                            idColumn.SetSize((ushort)(p._itemCount));
+                                if (lid == ushort.MaxValue)
+                                {
+                                    throw new ArribaWriteException(externalID, p.IDColumn.Name, externalID, new ArribaException("Column full in Partition. Unable to add items."));
+                                }
 
-                            if (typedIdColumn != null)
-                            {
-                                typedIdColumn[lid] = externalID;
-                            }
-                            else
-                            {
-                                idColumn[lid] = externalID;
-                            }
+                                p._itemCount++;
+                                idColumn.SetSize((ushort)(p._itemCount));
 
-                            newlyAssignedLIDs[externalID] = lid;
+                                if (typedIdColumn != null)
+                                {
+                                    typedIdColumn[lid] = externalID;
+                                }
+                                else
+                                {
+                                    idColumn[lid] = externalID;
+                                }
+
+                                newlyAssignedLIDs[externalID] = lid;
+                            }
                         }
+
+                        itemLIDs[i] = lid;
                     }
 
-                    itemLIDs[i] = lid;
+                    // Commit the updates to the values column if the column requires it (FastAddSortedColumn does)
+                    if (idColumn is ICommittable) (idColumn as ICommittable).Commit();
                 }
-
-                // Commit the updates to the values column if the column requires it (FastAddSortedColumn does)
-                if (idColumn is ICommittable) (idColumn as ICommittable).Commit();
 
                 return itemLIDs;
             }
@@ -443,6 +446,9 @@ namespace Arriba.Model
 
                 for (int rowIndex = 0, sourceItemIndex = chainStartIndex; rowIndex < rowCount; ++rowIndex, sourceItemIndex = partitionChains[sourceItemIndex])
                 {
+                    // If the item is new and no LID was assigned, we don't set values
+                    if (itemLIDs[rowIndex] == ushort.MaxValue) continue;
+
                     try
                     {
                         if (typedColumn != null)

--- a/Arriba/Arriba/Model/Table.cs
+++ b/Arriba/Arriba/Model/Table.cs
@@ -297,15 +297,6 @@ namespace Arriba.Model
         #endregion
 
         #region AddOrUpdate (insert, update)
-        public bool ShouldAddColumnsDynamically
-        {
-            get
-            {
-                // If a table has no data and no or one column, it's willing to add Columns dynamically discovered from the first block AddOrUpdated
-                return this.Count == 0 && _partitions[0].ColumnDetails.Count <= 1;
-            }
-        }
-
         public void AddColumnsFromBlock(DataBlock values)
         {
             bool foundIdColumn = (_partitions[0].IDColumn != null);
@@ -354,10 +345,7 @@ namespace Arriba.Model
         /// <param name="values">Set of Columns and values to add or update</param>
         public void AddOrUpdate(DataBlock values)
         {
-            AddOrUpdateOptions options = new Model.AddOrUpdateOptions();
-            options.AddMissingColumns = ShouldAddColumnsDynamically;
-
-            AddOrUpdate(values, options);
+            AddOrUpdate(values, new AddOrUpdateOptions());
         }
 
         /// <summary>

--- a/Arriba/Tools/Arriba.Csv/Program.cs
+++ b/Arriba/Tools/Arriba.Csv/Program.cs
@@ -19,15 +19,18 @@ namespace Arriba.Csv
     internal class Program
     {
         public const int QueryResultLimit = 40;
-        public const int BatchSize = 100;
-        public const long RequiredItemCount = 100000;
+        public const int BatchSize = 250;
 
         private const string Usage = @"
     Arriba.Csv builds or queries Arriba tables from CSV source data.
     Source data must include a unique ID column (the first column whose name ends with 'ID' or the first column).
+    'build' to create a new table and add all data.
+    'decorate' mode used to add new columns to existing rows only.
+    'query' to run a query from the command line.
     
-    Arriba.Csv /mode:build /table:<TableName> /csvPath:<CsvFilePath> [/maximumCount:<RowLimitForTable>]?
+    Arriba.Csv /mode:build /table:<TableName> /csvPath:<CsvFilePath> [/maximumCount:<RowLimitForTable>]? [/columns:""C1,C2,C3""]?
     Arriba.Csv /mode:query /table:<TableName> [/select:<ColumnList>]? [/orderBy:<ColumnName>]? [/count:<CountToShow>]?
+    Arriba.Csv /mode:decorate /table:<TableName> /csvPath:<CsvFilePath> [/maximumCount:<RowLimitForTable>]? [/columns:""C1,C2,C3""]?
 
     Ex:
       Arriba.Csv /mode:build /table:SP500 /csvPath:""C:\Temp\SP500 Price History.csv"" /maximumCount:50000
@@ -44,7 +47,10 @@ namespace Arriba.Csv
                 switch (mode)
                 {
                     case "build":
-                        Build(c.GetString("table"), c.GetString("csvPath"), c.GetInt("maximumCount", 100000));
+                        Build(true, c.GetString("table"), c.GetString("csvPath"), c.GetInt("maximumCount", 100000), c.GetString("columns", null));
+                        break;
+                    case "decorate":
+                        Build(false, c.GetString("table"), c.GetString("csvPath"), c.GetInt("maximumCount", 100000), c.GetString("columns", null));
                         break;
                     case "query":
                         Query(c.GetString("table"), c.GetString("select", ""), c.GetString("orderBy", ""), c.GetInt("count", QueryResultLimit));
@@ -61,20 +67,42 @@ namespace Arriba.Csv
             }
         }
 
-        private static void Build(string tableName, string csvFilePath, int maximumCount)
+        private static void Build(bool build, string tableName, string csvFilePath, int maximumCount, string columns)
         {
+            Stopwatch w = Stopwatch.StartNew();
             Console.WriteLine("Building Arriba table '{0}' from '{1}'...", tableName, csvFilePath);
 
-            Table table = new Table(tableName, RequiredItemCount);
+            IList<string> columnNames = null;
+            if (!String.IsNullOrEmpty(columns)) columnNames = SplitAndTrim(columns);
+
+            Table table;
+            if (build)
+            {
+                table = new Table(tableName, maximumCount);
+            }
+            else
+            { 
+                table = new Table();
+                table.Load(tableName);
+            }
+
+            // Always add missing columns. Add rows only when not in 'decorate' mode
+            AddOrUpdateOptions options = new AddOrUpdateOptions();
+            options.AddMissingColumns = true;
+            options.AddMissingRows = build;
+
             using (CsvReader reader = new CsvReader(csvFilePath))
             {
                 long rowsImported = 0;
 
                 foreach (DataBlock block in reader.ReadAsDataBlockBatch(BatchSize))
                 {
-                    table.AddOrUpdate(block);
+                    DataBlock toInsert = block;
+                    if (columnNames != null) toInsert = toInsert.StripToColumns(columnNames);
 
-                    rowsImported += block.RowCount;
+                    table.AddOrUpdate(toInsert);
+
+                    rowsImported += toInsert.RowCount;
                     Console.Write(".");
                 }
 
@@ -83,7 +111,8 @@ namespace Arriba.Csv
             }
 
             table.Save();
-            Console.WriteLine("Done.");
+            w.Stop();
+            Console.WriteLine("Done in {0}.", w.Elapsed.ToFriendlyString());
         }
 
         private static void Query(string tableName, string columnsToSelect, string orderByColumn, int countToShow)

--- a/Arriba/Tools/Arriba.Csv/Program.cs
+++ b/Arriba/Tools/Arriba.Csv/Program.cs
@@ -89,7 +89,7 @@ namespace Arriba.Csv
             // Always add missing columns. Add rows only when not in 'decorate' mode
             AddOrUpdateOptions options = new AddOrUpdateOptions();
             options.AddMissingColumns = true;
-            options.AddMissingRows = build;
+            options.Mode = (build ? AddOrUpdateMode.AddOrUpdate : AddOrUpdateMode.UpdateAndIgnoreAdds);
 
             using (CsvReader reader = new CsvReader(csvFilePath))
             {

--- a/Arriba/Tools/Arriba.Csv/Program.cs
+++ b/Arriba/Tools/Arriba.Csv/Program.cs
@@ -52,9 +52,6 @@ namespace Arriba.Csv
                     case "decorate":
                         Build(false, c.GetString("table"), c.GetString("csvPath"), c.GetInt("maximumCount", 100000), c.GetString("columns", null));
                         break;
-                    case "add":
-                        Build(true, c.GetString("table"), c.GetString("csvPath"), c.GetInt("maximumCount", 100000), c.GetString("columns", null));
-                        break;
                     case "query":
                         Query(c.GetString("table"), c.GetString("select", ""), c.GetString("orderBy", ""), c.GetInt("count", QueryResultLimit));
                         break;

--- a/Arriba/Tools/Arriba.Csv/Program.cs
+++ b/Arriba/Tools/Arriba.Csv/Program.cs
@@ -100,7 +100,7 @@ namespace Arriba.Csv
                     DataBlock toInsert = block;
                     if (columnNames != null) toInsert = toInsert.StripToColumns(columnNames);
 
-                    table.AddOrUpdate(toInsert);
+                    table.AddOrUpdate(toInsert, options);
 
                     rowsImported += toInsert.RowCount;
                     Console.Write(".");

--- a/Elfie/Elfie.Test/Elfie.Test.csproj
+++ b/Elfie/Elfie.Test/Elfie.Test.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.CodeAnalysis.Elfie.Test</RootNamespace>
     <AssemblyName>Elfie.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -86,6 +86,7 @@
     <Compile Include="SampleElfieStructure.V1.cs" />
     <Compile Include="SampleElfieStructure.cs" />
     <Compile Include="Serialization\TsvReaderTests.cs" />
+    <Compile Include="Serialization\TsvWriterTests.cs" />
     <Compile Include="Verify.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Elfie/Elfie.Test/Extensions/BinarySerializableTests.cs
+++ b/Elfie/Elfie.Test/Extensions/BinarySerializableTests.cs
@@ -3,9 +3,10 @@
 
 using System.IO;
 
+using Elfie.Test;
+
 using Microsoft.CodeAnalysis.Elfie.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Elfie.Test;
 
 namespace Microsoft.CodeAnalysis.Elfie.Test.Extensions
 {

--- a/Elfie/Elfie.Test/Model/AddReferenceDatabaseTests.cs
+++ b/Elfie/Elfie.Test/Model/AddReferenceDatabaseTests.cs
@@ -5,13 +5,14 @@ using System;
 using System.Diagnostics;
 using System.IO;
 
+using Elfie.Test;
+
 using Microsoft.CodeAnalysis.Elfie.Model;
 using Microsoft.CodeAnalysis.Elfie.Model.Strings;
 using Microsoft.CodeAnalysis.Elfie.Model.Structures;
 using Microsoft.CodeAnalysis.Elfie.Serialization;
 using Microsoft.CodeAnalysis.Elfie.Test.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Elfie.Test;
 
 namespace Microsoft.CodeAnalysis.Elfie.Test.Model
 {

--- a/Elfie/Elfie.Test/Model/PackageDatabaseTests.cs
+++ b/Elfie/Elfie.Test/Model/PackageDatabaseTests.cs
@@ -7,13 +7,14 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
+using Elfie.Test;
+
 using Microsoft.CodeAnalysis.Elfie.Extensions;
 using Microsoft.CodeAnalysis.Elfie.Model;
 using Microsoft.CodeAnalysis.Elfie.Model.Structures;
 using Microsoft.CodeAnalysis.Elfie.Serialization;
 using Microsoft.CodeAnalysis.Elfie.Test.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Elfie.Test;
 
 namespace Microsoft.CodeAnalysis.Elfie.Test.Model
 {

--- a/Elfie/Elfie.Test/Model/Strings/String8Tests.cs
+++ b/Elfie/Elfie.Test/Model/Strings/String8Tests.cs
@@ -136,6 +136,42 @@ namespace Microsoft.CodeAnalysis.Elfie.Test.Model.Strings
         }
 
         [TestMethod]
+        public void String8_ToInteger()
+        {
+            Assert.AreEqual(-1, TryToInteger(null));
+            Assert.AreEqual(-1, TryToInteger(String.Empty));
+            Assert.AreEqual(5, TryToInteger("5"));
+            Assert.AreEqual(12345, TryToInteger("12345"));
+            Assert.AreEqual(-1, TryToInteger("-6"));
+            Assert.AreEqual(int.MaxValue, TryToInteger(int.MaxValue.ToString()));
+            Assert.AreEqual(-1, TryToInteger("123g"));
+            Assert.AreEqual(-1, TryToInteger("9999999999"));
+            Assert.AreEqual(-1, TryToInteger("12345678901234567890"));
+        }
+
+        [TestMethod]
+        public void String8_FromInteger()
+        {
+            byte[] buffer = new byte[11];
+            Assert.AreEqual("0", String8.FromInteger(0, buffer).ToString());
+            Assert.AreEqual("9", String8.FromInteger(9, buffer).ToString());
+            Assert.AreEqual("-1", String8.FromInteger(-1, buffer).ToString());
+            Assert.AreEqual("-10", String8.FromInteger(-10, buffer).ToString());
+            Assert.AreEqual("99", String8.FromInteger(99, buffer).ToString());
+            Assert.AreEqual("100", String8.FromInteger(100, buffer).ToString());
+            Assert.AreEqual("-999", String8.FromInteger(-999, buffer).ToString());
+            Assert.AreEqual("123456789", String8.FromInteger(123456789, buffer).ToString());
+            Assert.AreEqual(int.MaxValue.ToString(), String8.FromInteger(int.MaxValue, buffer).ToString());
+            Assert.AreEqual(int.MinValue.ToString(), String8.FromInteger(int.MinValue, buffer).ToString());
+        }
+
+        private int TryToInteger(string value)
+        {
+            String8 value8 = String8.Convert(value, new byte[String8.GetLength(value)]);
+            return value8.ToInteger();
+        }
+
+        [TestMethod]
         public void String8_GetHashCode()
         {
             byte[] buffer = new byte[20];

--- a/Elfie/Elfie.Test/Model/Structures/PartialArrayTests.cs
+++ b/Elfie/Elfie.Test/Model/Structures/PartialArrayTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Elfie.Test;
+
 using Microsoft.CodeAnalysis.Elfie.Model.Structures;
 using Microsoft.CodeAnalysis.Elfie.Test.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/Elfie/Elfie.Test/Model/Tree/ItemTreeTests.cs
+++ b/Elfie/Elfie.Test/Model/Tree/ItemTreeTests.cs
@@ -4,11 +4,12 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 
+using Elfie.Test;
+
 using Microsoft.CodeAnalysis.Elfie.Model.Strings;
 using Microsoft.CodeAnalysis.Elfie.Model.Tree;
 using Microsoft.CodeAnalysis.Elfie.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Elfie.Test;
 
 namespace Microsoft.CodeAnalysis.Elfie.Test.Model
 {

--- a/Elfie/Elfie.Test/SampleElfieStructure.V1.cs
+++ b/Elfie/Elfie.Test/SampleElfieStructure.V1.cs
@@ -4,11 +4,11 @@
 using System;
 using System.IO;
 
+using Microsoft.CodeAnalysis.Elfie.Extensions;
 using Microsoft.CodeAnalysis.Elfie.Model;
 using Microsoft.CodeAnalysis.Elfie.Model.Strings;
 using Microsoft.CodeAnalysis.Elfie.Model.Structures;
 using Microsoft.CodeAnalysis.Elfie.Serialization;
-using Microsoft.CodeAnalysis.Elfie.Extensions;
 
 namespace Microsoft.CodeAnalysis.Elfie.Test
 {
@@ -45,8 +45,8 @@ namespace Microsoft.CodeAnalysis.Elfie.Test
         // The constructor is internal only - the set must create the items
         internal SampleItem_V1(SampleSet_V1 set, int index)
         {
-            this._set = set;
-            this._index = index;
+            _set = set;
+            _index = index;
         }
 
         // String properties are stored in a StringStore (and de-duped), which provides an int identifier

--- a/Elfie/Elfie.Test/SampleElfieStructure.cs
+++ b/Elfie/Elfie.Test/SampleElfieStructure.cs
@@ -74,32 +74,32 @@ namespace Microsoft.CodeAnalysis.Elfie.Test
         // String properties are stored as "String8" (a String in UTF8 byte[])
         public String8 Name
         {
-            get { return this._set.Name[_index]; }
-            set { this._set.Name[_index] = value; }
+            get { return _set.Name[_index]; }
+            set { _set.Name[_index] = value; }
         }
 
         public String8 Target
         {
-            get { return this._set.Target[_index]; }
-            set { this._set.Target[_index] = value; }
+            get { return _set.Target[_index]; }
+            set { _set.Target[_index] = value; }
         }
 
         // Enums and other non-primitives must be stored as primitives and converted
         public SampleItemType Type
         {
-            get { return (SampleItemType)this._set.Type[_index]; }
-            set { this._set.Type[_index] = (byte)value; }
+            get { return (SampleItemType)_set.Type[_index]; }
+            set { _set.Type[_index] = (byte)value; }
         }
 
         public DateTime EventTime
         {
-            get { return this._set.EventTime[_index].ToDateTime(); }
-            set { this._set.EventTime[_index] = value.ToLong(); }
+            get { return _set.EventTime[_index].ToDateTime(); }
+            set { _set.EventTime[_index] = value.ToLong(); }
         }
 
         public override string ToString()
         {
-            return this._index.ToString();
+            return _index.ToString();
         }
     }
 

--- a/Elfie/Elfie.Test/Serialization/TsvWriterTests.cs
+++ b/Elfie/Elfie.Test/Serialization/TsvWriterTests.cs
@@ -1,0 +1,141 @@
+﻿using Elfie.Test;
+using Microsoft.CodeAnalysis.Elfie.Extensions;
+using Microsoft.CodeAnalysis.Elfie.Model.Strings;
+using Microsoft.CodeAnalysis.Elfie.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Elfie.Test.Serialization
+{
+    [TestClass]
+    public class TsvWriterTests
+    {
+        [TestMethod]
+        public void TsvWriter_Basics()
+        {
+            String8Block block = new String8Block();
+            String8 valueNoEscaping = block.GetCopy("Sample Description");
+            String8 valueEscaping = block.GetCopy("Value\tWith\nIssues");
+
+            using (TsvWriter writer = new TsvWriter("TsvWriter.tsv", new string[] { "LineNumber", "Count", "Description", "Source" }))
+            {
+                Assert.AreEqual(1, writer.RowNumber);
+
+                int sum = 0;
+                for(int i = 1; i <= 10; ++i)
+                {
+                    Assert.AreEqual(i, writer.RowNumber);
+
+                    sum += i;
+                    writer.Write(i);
+                    writer.Write(sum);
+                    writer.Write(valueNoEscaping);
+                    writer.Write(valueEscaping);
+
+                    writer.NextRow();
+                }
+            }
+
+            string tsvContent = File.ReadAllText("TsvWriter.tsv");
+
+            // Verify header is as expected
+            Assert.IsTrue(tsvContent.StartsWith("LineNumber\tCount\tDescription\tSource\r\n"));            
+
+            // Verify illegal characters are stripped
+            Assert.IsTrue(tsvContent.Contains("ValueWithIssues"));
+
+            // Verify the first row fully
+            Assert.IsTrue(tsvContent.Contains("1\t1\tSample Description\tValueWithIssues\r\n"));
+        }
+
+        [TestMethod]
+        public void TsvWriter_RowValidation()
+        {
+            using (TsvWriter writer = new TsvWriter("TsvWriter_RowValidation.tsv", new string[] { "LineNumber", "Count", "Description", "Source" }))
+            {
+                writer.Write(1);
+                writer.Write(2);
+
+                // Verify exception if too few columns are written
+                Verify.Exception<TsvWriterException>(writer.NextRow);
+
+                writer.Write(3);
+                writer.Write(4);
+
+                // Verify exception if too many columns written
+                Verify.Exception<TsvWriterException>(() => writer.Write(5));
+
+                // No trailing NextRow()
+            }
+
+            // Verify last row terminated (despite no trailing NextRow)
+            string content = File.ReadAllText("TsvWriter_RowValidation.tsv");
+            Assert.IsTrue(content.EndsWith("\r\n"));
+        }
+
+#if !DEBUG
+        [TestMethod]
+#endif
+        public void TsvWriter_Performance()
+        {
+            String8Block block = new String8Block();
+            String8 d1 = block.GetCopy("Description 1");
+            String8 d2 = block.GetCopy("Description 2");
+            String8 s1 = block.GetCopy("Source: Internal");
+            String8 s2 = block.GetCopy("Source: External");
+
+            Stopwatch w = Stopwatch.StartNew();
+            long bytesWritten = 0;
+            int rowsWritten = 0;
+
+            int iterations = 50;
+            using (MemoryStream s = new MemoryStream())
+            {
+                for (int iteration = 0; iteration < iterations; ++iteration)
+                {
+                    s.Seek(0, SeekOrigin.Begin);
+
+                    TsvWriter writer = new TsvWriter(s, new string[] { "LineNumber", "Count", "Description", "Source" });
+                    
+                    int sum = 0;
+                    for (int row = 1; row < 10000; ++row)
+                    {
+                        sum += row;
+
+                        writer.Write(row);
+                        writer.Write(sum);
+
+                        if (row % 2 == 0)
+                        {
+                            writer.Write(d1);
+                            writer.Write(s1);
+                        }
+                        else
+                        {
+                            writer.Write(d2);
+                            writer.Write(s2);
+                        }
+
+                        writer.NextRow();
+                    }
+
+                    bytesWritten += writer.BytesWritten;
+                    rowsWritten += writer.RowNumber;
+                    
+                }
+
+            }
+            w.Stop();
+
+            // Tsv Write goal: 100MB/sec [100KB/ms]
+            // NOTE: Tsv Write performance is very sensitive the mix of text and numbers written. Writing integers is slower.
+            long targetMilliseconds = bytesWritten / 100000;
+            Trace.WriteLine(String.Format("Elfie TsvWriter wrote {0} ({1:n0} rows) in {2} [goal {3}ms]", bytesWritten.SizeString(), rowsWritten, w.Elapsed.ToFriendlyString(), targetMilliseconds));
+            Assert.IsTrue(w.ElapsedMilliseconds < targetMilliseconds);
+        }
+
+    }
+}

--- a/Elfie/Elfie.Test/Serialization/TsvWriterTests.cs
+++ b/Elfie/Elfie.Test/Serialization/TsvWriterTests.cs
@@ -1,12 +1,17 @@
-﻿using Elfie.Test;
-using Microsoft.CodeAnalysis.Elfie.Extensions;
-using Microsoft.CodeAnalysis.Elfie.Model.Strings;
-using Microsoft.CodeAnalysis.Elfie.Serialization;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+
+using Elfie.Test;
+
+using Microsoft.CodeAnalysis.Elfie.Extensions;
+using Microsoft.CodeAnalysis.Elfie.Model.Strings;
+using Microsoft.CodeAnalysis.Elfie.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CodeAnalysis.Elfie.Test.Serialization
 {
@@ -25,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Test.Serialization
                 Assert.AreEqual(1, writer.RowNumber);
 
                 int sum = 0;
-                for(int i = 1; i <= 10; ++i)
+                for (int i = 1; i <= 10; ++i)
                 {
                     Assert.AreEqual(i, writer.RowNumber);
 
@@ -42,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Test.Serialization
             string tsvContent = File.ReadAllText("TsvWriter.tsv");
 
             // Verify header is as expected
-            Assert.IsTrue(tsvContent.StartsWith("LineNumber\tCount\tDescription\tSource\r\n"));            
+            Assert.IsTrue(tsvContent.StartsWith("LineNumber\tCount\tDescription\tSource\r\n"));
 
             // Verify illegal characters are stripped
             Assert.IsTrue(tsvContent.Contains("ValueWithIssues"));
@@ -99,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Test.Serialization
                     s.Seek(0, SeekOrigin.Begin);
 
                     TsvWriter writer = new TsvWriter(s, new string[] { "LineNumber", "Count", "Description", "Source" });
-                    
+
                     int sum = 0;
                     for (int row = 1; row < 10000; ++row)
                     {
@@ -124,9 +129,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Test.Serialization
 
                     bytesWritten += writer.BytesWritten;
                     rowsWritten += writer.RowNumber;
-                    
                 }
-
             }
             w.Stop();
 
@@ -136,6 +139,5 @@ namespace Microsoft.CodeAnalysis.Elfie.Test.Serialization
             Trace.WriteLine(String.Format("Elfie TsvWriter wrote {0} ({1:n0} rows) in {2} [goal {3}ms]", bytesWritten.SizeString(), rowsWritten, w.Elapsed.ToFriendlyString(), targetMilliseconds));
             Assert.IsTrue(w.ElapsedMilliseconds < targetMilliseconds);
         }
-
     }
 }

--- a/Elfie/Elfie/Elfie.csproj
+++ b/Elfie/Elfie/Elfie.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Serialization\Read.cs" />
     <Compile Include="Model\Strings\String8Block.cs" />
     <Compile Include="Serialization\TsvReader.cs" />
+    <Compile Include="Serialization\TsvWriter.cs" />
     <Compile Include="Serialization\Write.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Elfie/Elfie/Model/BaseItemSet.cs
+++ b/Elfie/Elfie/Model/BaseItemSet.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model
             }
         }
 
-        public void WriteBinary(BinaryWriter w)
+        public virtual void WriteBinary(BinaryWriter w)
         {
             this.ConvertToImmutable();
 
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model
             }
         }
 
-        public void ReadBinary(BinaryReader r)
+        public virtual void ReadBinary(BinaryReader r)
         {
             this.Clear();
 

--- a/Elfie/Elfie/Model/BaseItemSet.cs
+++ b/Elfie/Elfie/Model/BaseItemSet.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model
         public BaseItemSet()
         {
             this.Strings = new StringStore();
-            this._columns = new List<IColumn>();
+            _columns = new List<IColumn>();
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model
         /// <param name="column">IColumn to add</param>
         protected void AddColumn(IColumn column)
         {
-            this._columns.Add(column);
+            _columns.Add(column);
         }
 
         #region IReadOnlyList<T>
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model
         /// </summary>
         public virtual T Add()
         {
-            foreach (IColumn column in this._columns)
+            foreach (IColumn column in _columns)
             {
                 column.Add();
             }
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model
         {
             this.Strings.Clear();
 
-            foreach (IColumn column in this._columns)
+            foreach (IColumn column in _columns)
             {
                 column.Clear();
             }
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model
         {
             if (this.Strings.ConvertToImmutable())
             {
-                foreach (IColumn column in this._columns)
+                foreach (IColumn column in _columns)
                 {
                     column.ConvertToImmutable();
                 }
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model
             w.Write(_count);
             this.Strings.WriteBinary(w);
 
-            foreach (IBinarySerializable column in this._columns)
+            foreach (IBinarySerializable column in _columns)
             {
                 column.WriteBinary(w);
             }
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model
             _count = r.ReadInt32();
             this.Strings.ReadBinary(r);
 
-            foreach (IBinarySerializable column in this._columns)
+            foreach (IBinarySerializable column in _columns)
             {
                 column.ReadBinary(r);
             }

--- a/Elfie/Elfie/Model/Strings/String8.cs
+++ b/Elfie/Elfie/Model/Strings/String8.cs
@@ -284,7 +284,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
             long valueLeft = value;
 
             // Write minus sign if negative
-            if(valueLeft < 0)
+            if (valueLeft < 0)
             {
                 valueLeft = -valueLeft;
                 buffer[i++] = (byte)'-';
@@ -293,14 +293,14 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
             // Determine how many digits in value
             int digits = 1;
             int scale = 10;
-            while(valueLeft >= scale && digits < 10)
+            while (valueLeft >= scale && digits < 10)
             {
                 digits++;
                 scale *= 10;
             }
 
             // Write digits right to left
-            for(int j = i + digits - 1; j >= i; --j)
+            for (int j = i + digits - 1; j >= i; --j)
             {
                 long digit = valueLeft % 10;
                 buffer[j] = (byte)(UTF8.Zero + (byte)digit);

--- a/Elfie/Elfie/Model/Strings/String8.cs
+++ b/Elfie/Elfie/Model/Strings/String8.cs
@@ -185,29 +185,6 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
 
         #region Basic Methods
         /// <summary>
-        ///  Convert a String8 with a non-negative integer [digits only] to the numeric value.
-        /// </summary>
-        /// <returns>Numeric Value or -1 if not an integer</returns>
-        public int ToInteger()
-        {
-            if (IsEmpty()) return -1;
-
-            long value = 0;
-            int end = _index + _length;
-            for (int i = _index; i < end; ++i)
-            {
-                int digitValue = this._buffer[i] - UTF8.Zero;
-                if (digitValue < 0 || digitValue > 9) return -1;
-
-                value *= 10;
-                value += digitValue;
-            }
-
-            if (value > int.MaxValue) return -1;
-            return (int)value;
-        }
-
-        /// <summary>
         ///  Return a String8 for the value of this string after the given index.
         /// </summary>
         /// <param name="index">Index from which to include characters</param>
@@ -272,6 +249,65 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
             }
 
             return -1;
+        }
+        #endregion
+
+        #region Type Conversions
+        /// <summary>
+        ///  Convert a String8 with a non-negative integer [digits only] to the numeric value.
+        /// </summary>
+        /// <returns>Numeric Value or -1 if not an integer</returns>
+        public int ToInteger()
+        {
+            if (IsEmpty()) return -1;
+
+            long value = 0;
+            int end = _index + _length;
+            for (int i = _index; i < end; ++i)
+            {
+                int digitValue = this._buffer[i] - UTF8.Zero;
+                if (digitValue < 0 || digitValue > 9) return -1;
+
+                value *= 10;
+                value += digitValue;
+                if (value > int.MaxValue) return -1;
+            }
+
+            return (int)value;
+        }
+
+        public static String8 FromInteger(int value, byte[] buffer)
+        {
+            if (buffer.Length < 11) throw new ArgumentException("String8.FromInteger requires an 11 byte buffer for integer conversion.");
+
+            int i = 0;
+            long valueLeft = value;
+
+            // Write minus sign if negative
+            if(valueLeft < 0)
+            {
+                valueLeft = -valueLeft;
+                buffer[i++] = (byte)'-';
+            }
+
+            // Determine how many digits in value
+            int digits = 1;
+            int scale = 10;
+            while(valueLeft >= scale && digits < 10)
+            {
+                digits++;
+                scale *= 10;
+            }
+
+            // Write digits right to left
+            for(int j = i + digits - 1; j >= i; --j)
+            {
+                long digit = valueLeft % 10;
+                buffer[j] = (byte)(UTF8.Zero + (byte)digit);
+                valueLeft /= 10;
+            }
+
+            return new String8(buffer, 0, i + digits);
         }
         #endregion
 

--- a/Elfie/Elfie/Model/Strings/String8Column.cs
+++ b/Elfie/Elfie/Model/Strings/String8Column.cs
@@ -20,46 +20,46 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
 
         public String8Column(StringStore strings)
         {
-            this._strings = strings;
-            this._identifiers = new PartialArray<int>();
+            _strings = strings;
+            _identifiers = new PartialArray<int>();
         }
 
         public String8 this[int index]
         {
-            get { return this._strings[this._identifiers[index]]; }
-            set { this._identifiers[index] = this._strings.FindOrAddString(value); }
+            get { return _strings[_identifiers[index]]; }
+            set { _identifiers[index] = _strings.FindOrAddString(value); }
         }
 
         public int Count
         {
-            get { return this._identifiers.Count; }
+            get { return _identifiers.Count; }
         }
 
         public void Clear()
         {
-            this._identifiers.Clear();
+            _identifiers.Clear();
         }
 
         public void Add()
         {
-            this._identifiers.Add();
+            _identifiers.Add();
         }
 
         public void ConvertToImmutable()
         {
-            this._strings.ConvertToImmutable(this._identifiers);
+            _strings.ConvertToImmutable(_identifiers);
         }
 
         public void WriteBinary(BinaryWriter w)
         {
             // StringStore is written separately
-            this._identifiers.WriteBinary(w);
+            _identifiers.WriteBinary(w);
         }
 
         public void ReadBinary(BinaryReader r)
         {
             // StringStore is read separately
-            this._identifiers.ReadBinary(r);
+            _identifiers.ReadBinary(r);
         }
     }
 }

--- a/Elfie/Elfie/Model/Strings/StringStore.cs
+++ b/Elfie/Elfie/Model/Strings/StringStore.cs
@@ -37,9 +37,9 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
 
         public void Clear()
         {
-            this._existingValues = null;
-            this._addedValues = null;
-            this._addedIdentifierToExistingIdentifier = null;
+            _existingValues = null;
+            _addedValues = null;
+            _addedIdentifierToExistingIdentifier = null;
         }
 
         #region Get Strings Out

--- a/Elfie/Elfie/Serialization/TsvWriter.cs
+++ b/Elfie/Elfie/Serialization/TsvWriter.cs
@@ -1,0 +1,142 @@
+﻿using Microsoft.CodeAnalysis.Elfie.Model.Strings;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace Microsoft.CodeAnalysis.Elfie.Serialization
+{
+    /// <summary>
+    ///  TsvReader is a high performance writer for the TSV (tab-separated value)
+    ///  format. The reader doesn't support escaped \t or \n in values (no standard
+    ///  for escaping seems to be defined).
+    ///  
+    ///  Usage:
+    ///  using (TsvWriter w = new TsvWriter(writeToPath, new string[] { "Name", "IPs" }))
+    ///  {
+    ///     while(/* ... data source .. */)
+    ///     {
+    ///         w.Write(name);
+    ///         w.Write(ips);
+    ///         w.NextRow();
+    ///     }
+    /// }
+    /// </summary>
+    public class TsvWriter : IDisposable
+    {
+        private Stream _stream;
+        private byte _cellDelimiter;
+
+        private int _columnCount;
+        private int _currentRowColumnCount;
+        private int _rowCount;
+
+        private byte[] _typeConversionBuffer;
+
+        public TsvWriter(string tsvFilePath, IEnumerable<string> columnNames) : 
+            this(new FileStream(tsvFilePath, FileMode.Create, FileAccess.Write, FileShare.None), columnNames)
+        { }
+
+        public TsvWriter(Stream stream, IEnumerable<string> columnNames)
+        {
+            _stream = stream;
+            _cellDelimiter = (byte)'\t';
+            _columnCount = columnNames.Count();
+            _currentRowColumnCount = 0;
+            _rowCount = 0;
+
+            _typeConversionBuffer = new byte[30];
+
+            // Write header row
+            String8Block buffer = new String8Block();
+            foreach (string columnName in columnNames)
+            {
+                Write(buffer.GetCopy(columnName));
+            }
+
+            NextRow();
+
+            if (_columnCount == 0) throw new TsvWriterException("No columns were passed to contructor. TSV must have at least one column.");
+        }
+
+        public void Write(String8 value)
+        {
+            WriteCellSeparator();
+
+            // Escaping: If value contains cell or row delimiter, just omit them
+            // No standard for TSV escaping.
+            int nextWriteStartIndex = 0;
+            int end = value._index + value._length;
+            for (int i = value._index; i < end; ++i)
+            {
+                byte c = value._buffer[i];
+                if (c == _cellDelimiter || c == (byte)'\n')
+                {
+                    int inStringIndex = i - value._index;
+                    value.Substring(nextWriteStartIndex, inStringIndex - nextWriteStartIndex).WriteTo(_stream);
+                    nextWriteStartIndex = inStringIndex + 1;
+                }
+            }
+
+            value.Substring(nextWriteStartIndex).WriteTo(_stream);
+        }
+
+        public void Write(int value)
+        {
+            WriteCellSeparator();
+            String8.FromInteger(value, _typeConversionBuffer).WriteTo(_stream);
+        }
+
+        public void NextRow()
+        {
+            if (_currentRowColumnCount != _columnCount) throw new TsvWriterException(String.Format("Wrote wrong number of columns for row {0:n0}. Wrote {1:n0}, expected {2:n0} columns.", _rowCount, _currentRowColumnCount, _columnCount));
+            WriteRowSeparator();   
+        }
+
+        private void WriteCellSeparator()
+        {
+            if (_currentRowColumnCount >= _columnCount) throw new TsvWriterException("Too many columns written to TsvWriter. Call NextRow after each row.");
+            if (_currentRowColumnCount > 0) _stream.WriteByte(_cellDelimiter);
+            _currentRowColumnCount++;
+        }
+
+        private void WriteRowSeparator()
+        {
+            _stream.WriteByte((byte)'\r');
+            _stream.WriteByte((byte)'\n');
+            _currentRowColumnCount = 0;
+            _rowCount++;
+        }
+
+        public int RowNumber
+        {
+            get { return _rowCount; }
+        }
+
+        public long BytesWritten
+        {
+            get { return _stream.Position; }
+        }
+
+        public void Dispose()
+        {
+            if (_stream != null)
+            {
+                if (_currentRowColumnCount > 0) WriteRowSeparator();
+                _stream.Dispose();
+                _stream = null;
+            }
+        }
+    }
+
+
+    [Serializable]
+    public class TsvWriterException : Exception
+    {
+        public TsvWriterException() { }
+        public TsvWriterException(string message) : base(message) { }
+        public TsvWriterException(string message, Exception inner) : base(message, inner) { }
+        protected TsvWriterException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+}

--- a/Elfie/Elfie/Serialization/TsvWriter.cs
+++ b/Elfie/Elfie/Serialization/TsvWriter.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.CodeAnalysis.Elfie.Model.Strings;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+
+using Microsoft.CodeAnalysis.Elfie.Model.Strings;
 
 namespace Microsoft.CodeAnalysis.Elfie.Serialization
 {
@@ -34,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
 
         private byte[] _typeConversionBuffer;
 
-        public TsvWriter(string tsvFilePath, IEnumerable<string> columnNames) : 
+        public TsvWriter(string tsvFilePath, IEnumerable<string> columnNames) :
             this(new FileStream(tsvFilePath, FileMode.Create, FileAccess.Write, FileShare.None), columnNames)
         { }
 
@@ -91,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
         public void NextRow()
         {
             if (_currentRowColumnCount != _columnCount) throw new TsvWriterException(String.Format("Wrote wrong number of columns for row {0:n0}. Wrote {1:n0}, expected {2:n0} columns.", _rowCount, _currentRowColumnCount, _columnCount));
-            WriteRowSeparator();   
+            WriteRowSeparator();
         }
 
         private void WriteCellSeparator()


### PR DESCRIPTION
- Elfie: Adding TsvWriter to allow writing out TSV. Pattern for converting integers without allocation.
- Arriba: Adding "AddOrUpdateOptions" to AddOrUpdate to allow controlling whether columns or rows are added per AddOrUpdate. This makes it easier to "decorate" tables with additional data only for items which exist and provides clean overrides for the "ShouldAddColumnsDynamically" heuristics.