### PR TITLE
TsvReader: Correctly strip '\r' on end of values before newline

### DIFF
--- a/Elfie/Elfie.Test/Serialization/TsvWriterTests.cs
+++ b/Elfie/Elfie.Test/Serialization/TsvWriterTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Text;
 
 using Elfie.Test;
 

--- a/Elfie/Elfie/Serialization/TsvReader.cs
+++ b/Elfie/Elfie/Serialization/TsvReader.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
         /// <summary>
         ///  Return the column headings found. The set is empty if there was no heading row.
         /// </summary>
-        public IEnumerable<string> Columns
+        public IReadOnlyList<string> Columns
         {
             get { return this._columnHeadingsList;  }
         }
@@ -121,6 +121,19 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
         /// <returns>String8 with value for column in current row. Throws if not enough columns in row.</returns>
         public String8 CurrentRow(int columnIndex)
         {
+            // If this is the last column and there's a trailing '\r', exclude it from the value
+            if(columnIndex == _currentRow.Count - 1)
+            {
+                String8 fullValue = _currentRow[columnIndex];
+                if (fullValue.Length > 0)
+                {
+                    byte lastCharacter = fullValue[fullValue.Length - 1];
+                    if (lastCharacter == '\r') fullValue = fullValue.Substring(0, fullValue.Length - 1);
+                }
+
+                return fullValue;
+            }
+
             return _currentRow[columnIndex];
         }
 
@@ -169,8 +182,8 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
             if (_nextRowIndexInBlock >= _currentBlock.Count) return false;
 
             // Get the next (complete) row from the current block
-            _currentLine++;
             _currentRow = _currentBlock[_nextRowIndexInBlock].Split(_cellDelimiter, _cellPositionArray);
+            _currentLine++;
             _nextRowIndexInBlock++;
 
             return true;

--- a/Elfie/Elfie/Serialization/TsvWriter.cs
+++ b/Elfie/Elfie/Serialization/TsvWriter.cs
@@ -45,8 +45,9 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
         /// <param name="tsvFilePath">Path to file to write.</param>
         /// <param name="columnNames">Column Names to write out.</param>
         /// <param name="writeHeaderRow">True to write a header row, False otherwise.</param>
-        public TsvWriter(string tsvFilePath, IEnumerable<string> columnNames, bool writeHeaderRow = true) :
-            this(new FileStream(tsvFilePath, FileMode.Create, FileAccess.Write, FileShare.None), columnNames, writeHeaderRow)
+        /// /// <param name="cellDelimiter">Delimiter between cells, default is tab.</param>
+        public TsvWriter(string tsvFilePath, IEnumerable<string> columnNames, bool writeHeaderRow = true, char cellDelimiter = '\t') :
+            this(new FileStream(tsvFilePath, FileMode.Create, FileAccess.Write, FileShare.None), columnNames, writeHeaderRow, cellDelimiter)
         { }
 
         /// <summary>


### PR DESCRIPTION
Merging a fix which caused data errors using TsvReader - if lines were \r\n terminated, \r was returned when asking for the value of the last column.