### PR TITLE
Add IColumn extensibility to Arriba

### DIFF
--- a/Arriba/Arriba.Test/Arriba.Test.csproj
+++ b/Arriba/Arriba.Test/Arriba.Test.csproj
@@ -97,6 +97,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="CustomColumn.cs" />
     <Compile Include="Verify.cs" />
     <Compile Include="Model\AggregatorTests.cs" />
     <Compile Include="Model\Correctors\ExpressionCorrectorTests.cs" />

--- a/Arriba/Arriba.Test/CustomColumn.cs
+++ b/Arriba/Arriba.Test/CustomColumn.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using Arriba.Model;
+using System.Collections.Generic;
+using Arriba.Model.Expressions;
+using Arriba.Structures;
+using Arriba.Serialization;
+
+namespace Arriba.Test
+{
+    public static class CustomColumnSupport
+    {
+        public static void RegisterCustomColumns()
+        {
+            ColumnFactory.AddColumnCreator("color", (details, columnComponents, initialCapacity) =>
+            {
+                IColumn<ColorColumn.ComparableColor> coreColumn = new ColorColumn();
+                IUntypedColumn utc = new UntypedColumn<ColorColumn.ComparableColor>(coreColumn);
+
+                utc.Name = details.Name;
+
+                return utc;
+            });
+        }
+    }
+
+    public class ColorTable : Table
+    {
+        public ColorTable(string name, long requiredItemCount) : base(name, requiredItemCount)
+        {
+        }
+
+        public void BindColorColumns(string sourceColumn, string targetColorColumn)
+        {
+            foreach (Partition p in GetPartitions())
+            {
+                IUntypedColumn srcColumn = p.Columns[sourceColumn];
+                IUntypedColumn colorColumn = p.Columns[targetColorColumn];
+                (colorColumn.InnerColumn as ColorColumn).LookupColumn = (IColumn<short>)srcColumn.InnerColumn;
+            }            
+        }
+    }
+
+    public class ColorColumn : IColumn<ColorColumn.ComparableColor>
+    {
+        public ColorColumn()
+        {
+        }
+
+        public IColumn<short> LookupColumn { get; set; }
+
+        public ComparableColor this[ushort lid]
+        {
+            get { return new ComparableColor() { ColorValue = (Color)(LookupColumn[lid] % (int)Color.Count) }; }
+            set { throw new NotImplementedException(); }
+        }
+
+        public ushort Count { get; private set; }
+
+        public ComparableColor DefaultValue { get { return new ComparableColor() { ColorValue = Color.None }; } }
+
+        public IColumn InnerColumn { get { return null; } }
+
+        public string Name { get; set; }
+
+        public Array GetValues(IList<ushort> lids)
+        {
+            if (lids == null)
+            {
+                throw new ArgumentNullException("lids");
+            }
+
+            int count = lids.Count;
+
+            ComparableColor[] result = new ComparableColor[count];
+            for (int i = 0; i < count; ++i)
+            {
+                result[i] = this[lids[i]];
+            }
+
+            return result;
+        }
+
+        public void SetSize(ushort size)
+        {
+            this.Count = size;
+        }
+
+        public bool TryEvaluate(ushort lid, Operator op, ComparableColor value, out bool result)
+        {
+            ComparableColor itemValue = this[lid];
+            return itemValue.TryEvaluate(op, value, out result);
+        }
+
+        public bool TryGetIndexOf(ComparableColor value, out ushort index)
+        {
+            // Base column doesn't contain sorting information
+            index = ushort.MaxValue;
+            return false;
+        }
+
+        public bool TryGetSortedIndexes(out IList<ushort> sortedIndexes, out int sortedIndexesCount)
+        {
+            // Base column doesn't contain sorting information
+            sortedIndexes = null;
+            sortedIndexesCount = 0;
+            return false;
+        }
+
+        public void TryWhere(Operator op, ComparableColor value, ShortSet result, ExecutionDetails details)
+        {
+            // Base Column can't identify matches for any operator in bulk efficiently.
+            if (details != null)
+            {
+                details.AddError(ExecutionDetails.ColumnDoesNotSupportOperator, op, this.Name);
+            }
+        }
+
+        public void VerifyConsistency(VerificationLevel level, ExecutionDetails details)
+        {
+        }
+
+        public void ReadBinary(ISerializationContext context)
+        {
+        }
+
+        public void WriteBinary(ISerializationContext context)
+        {
+        }
+
+        public enum Color
+        {
+            None,
+            Red,
+            Blue,
+            Green,
+            Count
+        }
+
+        public struct ComparableColor : IComparable<ComparableColor>, IEquatable<ComparableColor>
+        {
+            public Color ColorValue;
+
+            public int CompareTo(ComparableColor other)
+            {
+                return this.ColorValue.CompareTo(other.ColorValue);
+            }
+
+            public bool Equals(ComparableColor other)
+            {
+                return this.ColorValue == other.ColorValue;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is ComparableColor) return this.Equals((ComparableColor)obj);
+
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return this.ColorValue.GetHashCode();
+            }
+
+            public override string ToString()
+            {
+                return this.ColorValue.ToString();
+            }
+        }
+    }
+
+}

--- a/Arriba/Arriba.Test/Model/ColumnFactoryTests.cs
+++ b/Arriba/Arriba.Test/Model/ColumnFactoryTests.cs
@@ -6,7 +6,6 @@ using System.Text;
 
 using Arriba.Model;
 using Arriba.Model.Column;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Arriba.Test.Model
@@ -15,6 +14,12 @@ namespace Arriba.Test.Model
     public class ColumnFactoryTests
     {
         private string _defaultWrappingFormatString = "UntypedColumn<{0}>;FastAddSortedColumn<{0}>;ValueTypeColumn<{0}>";
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            ColumnFactory.ResetColumnCreators();
+        }
 
         [TestMethod]
         public void ColumnFactory_Basic()
@@ -46,6 +51,17 @@ namespace Arriba.Test.Model
             Assert.AreEqual(String.Format(_defaultWrappingFormatString, "Single"), WriteCompleteType(ColumnFactory.Build(new ColumnDetails("Unused", "Single", -1.0), 0)));
             Assert.AreEqual(String.Format(_defaultWrappingFormatString, "Single"), WriteCompleteType(ColumnFactory.Build(new ColumnDetails("Unused", "float", -1.0), 0)));
             Assert.AreEqual(String.Format(_defaultWrappingFormatString, "Double"), WriteCompleteType(ColumnFactory.Build(new ColumnDetails("Unused", "double", -1), 0)));
+        }
+
+        [TestMethod]
+        public void ColumnFactory_BasicExtensibility()
+        {
+            CustomColumnSupport.RegisterCustomColumns();
+            // Registering the same name twice throws an exception
+            Verify.Exception<ArribaException>(() => CustomColumnSupport.RegisterCustomColumns());
+
+            // Column factory can call custom column creators
+            Assert.AreEqual("UntypedColumn<ComparableColor>;ColorColumn", WriteCompleteType(ColumnFactory.Build(new ColumnDetails("Unused", "color", null), 0)));
         }
 
         /// <summary>
@@ -94,5 +110,6 @@ namespace Arriba.Test.Model
                 result.Append(">");
             }
         }
+
     }
 }

--- a/Arriba/Arriba/Model/Column/ColumnFactory.cs
+++ b/Arriba/Arriba/Model/Column/ColumnFactory.cs
@@ -19,6 +19,11 @@ namespace Arriba
         private static Dictionary<string, COLUMN_CREATOR> ColumnCreators;
         static ColumnFactory()
         {
+            ResetColumnCreators();
+        }
+
+        internal static void ResetColumnCreators()
+        {
             ColumnCreators = new Dictionary<string, COLUMN_CREATOR>();
 
             ColumnCreators["bool"] = (details, columnComponents, initialCapacity) =>

--- a/Arriba/Arriba/Model/Column/ColumnFactory.cs
+++ b/Arriba/Arriba/Model/Column/ColumnFactory.cs
@@ -107,7 +107,7 @@ namespace Arriba
         /// <param name="details">Name of column to create</param>
         /// <param name="initialCapacity">Initial storage capacity of the column; use to avoid resizes if the item count is known</param>
         /// <returns>IColumn of requested type</returns>
-        public static IUntypedColumn Build(ColumnDetails details, ushort initialCapacity)
+        internal static IUntypedColumn Build(ColumnDetails details, ushort initialCapacity)
         {
             string[] columnComponents = details.Type.ToLowerInvariant().Split(':');
             string coreType = columnComponents[columnComponents.Length - 1];

--- a/Arriba/Arriba/Model/Table.cs
+++ b/Arriba/Arriba/Model/Table.cs
@@ -118,6 +118,11 @@ namespace Arriba.Model
             }
         }
 
+        protected IReadOnlyList<Partition> GetPartitions()
+        {
+            return _partitions.AsReadOnly();
+        }
+
         #region Column Operations
         public ColumnDetails IDColumn
         {


### PR DESCRIPTION
This change adds the ability to allow external IColumn implementations to be used within a table.