### PR TITLE
Join Prototype [out for design comments]

### DIFF
--- a/Arriba/Arriba.Test/Arriba.Test.csproj
+++ b/Arriba/Arriba.Test/Arriba.Test.csproj
@@ -97,6 +97,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Indexing\SetSplitterTests.cs" />
     <Compile Include="Model\DatabaseTests.cs" />
     <Compile Include="Verify.cs" />
     <Compile Include="Model\AggregatorTests.cs" />

--- a/Arriba/Arriba.Test/Arriba.Test.csproj
+++ b/Arriba/Arriba.Test/Arriba.Test.csproj
@@ -97,6 +97,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Model\DatabaseTests.cs" />
     <Compile Include="Verify.cs" />
     <Compile Include="Model\AggregatorTests.cs" />
     <Compile Include="Model\Correctors\ExpressionCorrectorTests.cs" />

--- a/Arriba/Arriba.Test/Indexing/SetSplitterTests.cs
+++ b/Arriba/Arriba.Test/Indexing/SetSplitterTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Arriba.Indexing;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Arriba.Test.Indexing
+{
+    [TestClass]
+    public class SetSplitterTests : WordSplitterTestBase
+    {
+        public SetSplitterTests() :
+            base(new SetSplitter())
+        { }
+
+        [TestMethod]
+        public void SetSplitter_Basic()
+        {
+            Assert.AreEqual("", SplitAndJoin(""));
+            Assert.AreEqual("Single Value, no semi-colon", SplitAndJoin("Single Value, no semi-colon"));
+            Assert.AreEqual("One|Two", SplitAndJoin("One; Two"));
+            Assert.AreEqual("No|Space|Between|Values", SplitAndJoin("No;Space;Between;Values"));
+            Assert.AreEqual("Leading|And|Trailing", SplitAndJoin(";Leading;And;Trailing;"));
+        }
+    }
+}

--- a/Arriba/Arriba.Test/Model/DatabaseTests.cs
+++ b/Arriba/Arriba.Test/Model/DatabaseTests.cs
@@ -19,6 +19,7 @@ namespace Arriba.Test.Model
         public void Database_Join()
         {
             Database db = new Database();
+
             Table people = db.AddTable("People", 1000);
             people.AddOrUpdate(new DataBlock(new string[] { "Alias", "Name", "Team", "Groups" }, 3,
                 new Array[]
@@ -46,6 +47,7 @@ namespace Arriba.Test.Model
                 new SelectQuery() { Where = SelectQuery.ParseWhere("T1"), TableName = "People" }
             );
 
+            q.Correct(null);
             result = db.Query(q);
             Assert.AreEqual("O5, O3, O2, O1", JoinResultColumn(result));
 
@@ -56,6 +58,7 @@ namespace Arriba.Test.Model
                 new SelectQuery() { Where = SelectQuery.ParseWhere("mikefan"), TableName = "People" }
             );
 
+            q.Correct(null);
             result = db.Query(q);
             Assert.AreEqual("rtaket, mikefan", JoinResultColumn(result));
 
@@ -67,20 +70,6 @@ namespace Arriba.Test.Model
             //  Join returns too many
             //  Select column from Join is unknown
             //  Nested Join
-        }
-
-        private SelectResult RunQuerySet(Database db, SelectQuery q, IList<SelectQuery> joins)
-        {
-            Trace.WriteLine(String.Format("Raw Query: {0}", q.Where));
-
-            // Correct the Query [evaluating Joins recursively]
-            JoinCorrector j = new JoinCorrector(db, null, joins);
-            q.Correct(j);
-
-            // Get direct Query results
-            Trace.WriteLine(String.Format("Joined Query: {0}", q.Where));
-            SelectResult result = db[q.TableName].Select(q);
-            return result;
         }
 
         private string JoinResultColumn(SelectResult result, int columnIndex = 0)

--- a/Arriba/Arriba.Test/Model/DatabaseTests.cs
+++ b/Arriba/Arriba.Test/Model/DatabaseTests.cs
@@ -1,0 +1,65 @@
+﻿using Arriba.Model;
+using Arriba.Model.Correctors;
+using Arriba.Model.Query;
+using Arriba.Structures;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Arriba.Test.Model
+{
+    [TestClass]
+    public class DatabaseTests
+    {
+        [TestMethod]
+        public void Database_Join()
+        {
+            Database d = new Database();
+            Table people = d.AddTable("People", 1000);
+            people.AddOrUpdate(new DataBlock(new string[] { "Alias", "Name", "Team" }, 3,
+                new Array[]
+                {
+                    new string[] { "mikefan", "rtaket", "v-scolo" },
+                    new string[] { "Michael Fanning", "Ryley Taketa", "Scott Louvau"},
+                    new string[] { "T1", "T1", "T2" }
+                }), new AddOrUpdateOptions() { AddMissingColumns = true });
+
+            Table orders = d.AddTable("Orders", 1000);
+            orders.AddOrUpdate(new DataBlock(new string[] { "OrderNumber", "OrderedByAlias" }, 5,
+                new Array[]
+                {
+                    new string[] { "O1", "O2", "O3", "O4", "O5" },
+                    new string[] { "mikefan", "mikefan", "rtaket", "v-scolo", "rtaket" }
+                }), new AddOrUpdateOptions() { AddMissingColumns = true });
+
+            
+            // Ask for Orders where the Alias is in the joined query
+            SelectQuery q = new SelectQuery() { Where = SelectQuery.ParseWhere("OrderedByAlias=#Q1[Alias]"), TableName = "Orders" };
+
+            // Ask for People in Team T1
+            List<SelectQuery> querySet = new List<SelectQuery>();
+            querySet.Add(new SelectQuery() { Where = SelectQuery.ParseWhere("T1"), TableName = "People" });
+
+            // Correct the query - should convert to OrderedByAlias IN (rtaket, mikefan)
+            JoinCorrector j = new JoinCorrector(d, null, querySet);
+            q.Correct(j);
+            Assert.AreEqual("OrderedByAlias = IN(rtaket, mikefan)", q.Where.ToString());
+
+            // Ask for the outer query result - should get all except O4
+            SelectResult result = d[q.TableName].Select(q);
+            Assert.AreEqual(4, (int)result.Total);
+
+            // TODO:
+            //  Unknown column in Join query
+            //  Reference Join query out of range
+            //  Join returns nothing
+            //  Join returns too many
+            //  Select column from Join is unknown
+            //  Join on 'contains' (rather than equals)
+            //  Nested Join
+        }
+    }
+}

--- a/Arriba/Arriba.Test/Model/DatabaseTests.cs
+++ b/Arriba/Arriba.Test/Model/DatabaseTests.cs
@@ -40,23 +40,23 @@ namespace Arriba.Test.Model
             SelectResult result;
 
             // Get Orders where OrderedByAlias is any Alias matching "T1" in People (equals JOIN)
-            result = RunQuerySet(db,
+            JoinQuery<SelectResult> q = new JoinQuery<SelectResult>(
+                db,
                 new SelectQuery() { Where = SelectQuery.ParseWhere("OrderedByAlias=#Q1[Alias]"), TableName = "Orders", Columns = new string[] { "OrderNumber" } },
-                new SelectQuery[]
-                {
-                    new SelectQuery() { Where = SelectQuery.ParseWhere("T1"), TableName = "People" }
-                });
+                new SelectQuery() { Where = SelectQuery.ParseWhere("T1"), TableName = "People" }
+            );
 
+            result = db.Query(q);
             Assert.AreEqual("O5, O3, O2, O1", JoinResultColumn(result));
 
             // Get People where Groups contains a Group Mike is in (contains self JOIN)
-            result = RunQuerySet(db,
+            q = new JoinQuery<SelectResult>(
+                db,
                 new SelectQuery() { Where = SelectQuery.ParseWhere("Groups:#Q1[Groups]"), TableName = "People", Columns = new string[] { "Alias" } },
-                new SelectQuery[]
-                {
-                    new SelectQuery() { Where = SelectQuery.ParseWhere("mikefan"), TableName = "People" }
-                });
+                new SelectQuery() { Where = SelectQuery.ParseWhere("mikefan"), TableName = "People" }
+            );
 
+            result = db.Query(q);
             Assert.AreEqual("rtaket, mikefan", JoinResultColumn(result));
 
 
@@ -86,7 +86,7 @@ namespace Arriba.Test.Model
         private string JoinResultColumn(SelectResult result, int columnIndex = 0)
         {
             StringBuilder values = new StringBuilder();
-            for(int i = 0; i < result.Values.RowCount; ++i)
+            for (int i = 0; i < result.Values.RowCount; ++i)
             {
                 if (values.Length > 0) values.Append(", ");
                 values.Append(result.Values[i, columnIndex].ToString());

--- a/Arriba/Arriba/Arriba.csproj
+++ b/Arriba/Arriba/Arriba.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="FileLock.cs" />
     <Compile Include="Indexing\IWordSplitter.cs" />
+    <Compile Include="Indexing\Splitters\SetSplitter.cs" />
     <Compile Include="Model\AddOrUpdateOptions.cs" />
     <Compile Include="Model\Column\BooleanColumn.cs" />
     <Compile Include="Model\Column\ColumnDetails.cs" />

--- a/Arriba/Arriba/Arriba.csproj
+++ b/Arriba/Arriba/Arriba.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Model\Query\DistinctQuery.cs" />
     <Compile Include="Model\Query\DistinctResult.cs" />
     <Compile Include="Model\Query\IQuery.cs" />
+    <Compile Include="Model\Query\JoinQuery.cs" />
     <Compile Include="Serialization\BinarySerializable.cs" />
     <Compile Include="Serialization\CollectionFactory.cs" />
     <Compile Include="Serialization\CSV\CsvCellRange.cs" />

--- a/Arriba/Arriba/Arriba.csproj
+++ b/Arriba/Arriba/Arriba.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Model\Column\BooleanColumn.cs" />
     <Compile Include="Model\Column\ColumnDetails.cs" />
     <Compile Include="Model\Column\FastAddSortedColumn.cs" />
+    <Compile Include="Model\Correctors\JoinCorrector.cs" />
     <Compile Include="Model\Correctors\ColumnAliasCorrector.cs" />
     <Compile Include="Model\Correctors\ComposedCorrector.cs" />
     <Compile Include="Model\Correctors\TodayCorrector.cs" />

--- a/Arriba/Arriba/Indexing/Splitters/SetSplitter.cs
+++ b/Arriba/Arriba/Indexing/Splitters/SetSplitter.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Arriba.Serialization;
+using Arriba.Structures;
+
+namespace Arriba.Indexing
+{
+    /// <summary>
+    ///  SetSplitter splits text delimited by "; " into individual items.
+    /// </summary>
+    public class SetSplitter : IWordSplitter
+    {
+        public void Split(byte[] text, Range withinRange, RangeSet result)
+        {
+            if (result == null) throw new ArgumentNullException("result");
+            if (text == null) return;
+
+            int lastGroup = withinRange.Index;
+            int end = withinRange.Index + withinRange.Length;
+            int i;
+            for (i = withinRange.Index; i < end; ++i)
+            {
+                byte c = text[i];
+
+                if(c == UTF8.Semicolon)
+                {
+                    result.Add(lastGroup, i - lastGroup);
+                    lastGroup = i + 1;
+                    if (lastGroup < end && text[lastGroup] == UTF8.Space) lastGroup++;
+                }
+            }
+
+            // Include the last value
+            result.Add(lastGroup, i - lastGroup);
+        }
+    }
+}

--- a/Arriba/Arriba/Model/Column/ColumnFactory.cs
+++ b/Arriba/Arriba/Model/Column/ColumnFactory.cs
@@ -46,6 +46,11 @@ namespace Arriba
                     columnComponents = new string[] { "indexed[html]", "sorted", "string" };
                     coreType = "string";
                 }
+                else if(coreType.Equals("stringset"))
+                {
+                    columnComponents = new string[] { "indexed[set]", "sorted", "string" };
+                    coreType = "string";
+                }
                 else if (coreType.Equals("string") || coreType.Equals("json"))
                 {
                     columnComponents = new string[] { "indexed", "sorted", "string" };
@@ -187,6 +192,8 @@ namespace Arriba
                     return new DefaultWordSplitter();
                 case "html":
                     return new HtmlWordSplitter(new DefaultWordSplitter());
+                case "set":
+                    return new SetSplitter();
                 default:
                     throw new ArribaException(StringExtensions.Format("Word Splitter '{0}' is not currently supported.", descriptor));
             }

--- a/Arriba/Arriba/Model/Correctors/JoinCorrector.cs
+++ b/Arriba/Arriba/Model/Correctors/JoinCorrector.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Arriba.Model.Column;
+using Arriba.Model.Expressions;
+using System.Text.RegularExpressions;
+using Arriba.Model.Query;
+
+namespace Arriba.Model.Correctors
+{
+    /// <summary>
+    ///  JoinCorrector replaces column references from other queries
+    ///  with the collection of required values.
+    /// </summary>
+    public class JoinCorrector : TermCorrector
+    {
+        private Database DB { get; set; }
+        private ICorrector NestedCorrector { get; set; }
+        private IList<SelectQuery> Queries { get; set; }
+
+        public JoinCorrector(Database db, ICorrector nestedCorrector, IList<SelectQuery> querySet)
+        {
+            this.DB = db;
+            this.NestedCorrector = nestedCorrector;
+            this.Queries = querySet;
+        }
+
+        public override IExpression CorrectTerm(TermExpression te)
+        {
+            if (te == null) throw new ArgumentNullException("te");
+
+            // Look for a join term in the query
+            string value = te.Value.ToString();
+            if(value.StartsWith("#Q"))
+            {
+                Regex referenceExpression = new Regex(@"#Q(?<number>\d+)\[(?<columnName>[^\]]+)\]");
+                Match m = referenceExpression.Match(value);
+                if(m.Success)
+                {
+                    int referencedQuery = int.Parse(m.Groups["number"].Value);
+                    string referencedColumn = m.Groups["columnName"].Value;
+
+                    // Get the referenced query and recursively Join it, if required [1-based]
+                    SelectQuery joinQuery = this.Queries[referencedQuery - 1];
+                    joinQuery.Correct(this.NestedCorrector);
+                    joinQuery.Correct(this);
+
+                    // Ask for the Join column and maximum number of values
+                    joinQuery.Columns = new string[] { referencedColumn };
+                    joinQuery.Count = ushort.MaxValue;
+
+                    // Run the query
+                    Table t = this.DB[joinQuery.TableName];
+                    SelectResult result = t.Select(joinQuery);
+
+                    if(result.CountReturned == 0)
+                    {
+                        return new TermExpression(te.ColumnName, te.Operator, "\"\"");
+                    }
+                    else
+                    {
+                        return new TermInExpression(te.ColumnName, te.Operator, result.Values.GetColumn(0));
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Arriba/Arriba/Model/Database.cs
+++ b/Arriba/Arriba/Model/Database.cs
@@ -9,6 +9,7 @@ using System.Threading;
 
 using Arriba.Extensions;
 using Arriba.Serialization;
+using Arriba.Model.Query;
 
 namespace Arriba.Model
 {
@@ -23,6 +24,11 @@ namespace Arriba.Model
 
         public Database()
         { }
+
+        public virtual T Query<T>(IQuery<T> query)
+        {
+            return this[query.TableName].Query(query);
+        }
 
         public Table this[string tableName]
         {

--- a/Arriba/Arriba/Model/Expressions/Expressions.cs
+++ b/Arriba/Arriba/Model/Expressions/Expressions.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Arriba.Extensions;
 using Arriba.Model.Query;
 using Arriba.Structures;
+using Arriba.Indexing;
 
 namespace Arriba.Model.Expressions
 {
@@ -270,6 +271,43 @@ namespace Arriba.Model.Expressions
             this.ColumnName = columnName;
             this.Operator = op;
             this.Values = values;
+            
+            // If this is a "Matches" JOIN, split the values coming in into terms
+            // which will each be matched.
+            if(op == Operator.Matches || op == Operator.MatchesExact)
+            {
+                this.Values = GetUniqueTerms(values);
+            }
+        }
+
+        private Array GetUniqueTerms(Array values)
+        {
+            HashSet<ByteBlock> uniqueValues = new HashSet<ByteBlock>();
+           
+            // Get every unique word split from every value in the array
+            SetSplitter s = new SetSplitter();
+            for (int i = 0; i < values.Length; ++i)
+            {
+                ByteBlock value = (ByteBlock)values.GetValue(i);
+                foreach (Range r in s.Split(value).Ranges)
+                {
+                    if (r.Length > 0)
+                    {
+                        uniqueValues.Add(new ByteBlock(value.Array, r.Index, r.Length));
+                    }
+                }
+            }
+
+            // Convert the result to an array
+            ByteBlock[] result = new ByteBlock[uniqueValues.Count];
+            int j = 0;
+            foreach (ByteBlock value in uniqueValues)
+            {
+                result[j] = value;
+                j++;
+            }
+
+            return result;
         }
 
         public void TryEvaluate(Partition partition, ShortSet result, ExecutionDetails details)

--- a/Arriba/Arriba/Model/Expressions/Expressions.cs
+++ b/Arriba/Arriba/Model/Expressions/Expressions.cs
@@ -259,11 +259,16 @@ namespace Arriba.Model.Expressions
     public class TermInExpression : IExpression
     {
         public string ColumnName;
+        public Operator Operator;
         public Array Values;
 
-        public TermInExpression(string columnName, Array values)
+        public TermInExpression(string columnName, Array values) : this(columnName, Operator.Equals, values)
+        { }
+
+        public TermInExpression(string columnName, Operator op, Array values)
         {
             this.ColumnName = columnName;
+            this.Operator = op;
             this.Values = values;
         }
 
@@ -283,7 +288,7 @@ namespace Arriba.Model.Expressions
 
                 for (int i = 0; i < this.Values.Length; ++i)
                 {
-                    column.TryWhere(Operator.Equals, this.Values.GetValue(i), result, details);
+                    column.TryWhere(this.Operator, this.Values.GetValue(i), result, details);
                 }
             }
         }
@@ -297,11 +302,19 @@ namespace Arriba.Model.Expressions
         {
             StringBuilder result = new StringBuilder();
             result.Append(this.ColumnName);
-            result.Append(" IN (");
+            result.Append(this.Operator.ToSyntaxString());
+            result.Append("IN(");
 
             for (int i = 0; i < this.Values.Length; ++i)
             {
                 if (i > 0) result.Append(", ");
+
+                if (i > 4)
+                {
+                    result.AppendFormat("... [{0:n0}]", this.Values.Length);
+                    break;
+                }
+
                 result.Append(this.Values.GetValue(i).ToString());
             }
 

--- a/Arriba/Arriba/Model/Query/JoinQuery.cs
+++ b/Arriba/Arriba/Model/Query/JoinQuery.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using Arriba.Model.Correctors;
+using Arriba.Model.Expressions;
+
+namespace Arriba.Model.Query
+{
+    /// <summary>
+    ///  IQuery wrapper which implements Joins.
+    ///  During correction, the JoinCorrector corrects additional joined queries
+    ///  and then replaces terms in the primary query by evaluating the referenced join
+    ///  and getting all results for the specified column.
+    ///  
+    ///  For example, if we have:
+    ///    Q = [GroupName]:Nice AND [Members]::#Q1[Alias]
+    ///    Q1 = [TeamName]:T1
+    ///    
+    ///  Then correcting 'Q' will cause the JoinCorrector to run Q1, get all
+    ///  values for the 'Alias' column, split them, and replace [Members]::#Q1[Alias]
+    ///  with [Members]:: IN(alias1, alias2, alias3, ...).
+    /// </summary>
+    public class JoinQuery<T> : IQuery<T>
+    {
+        public Database DB { get; set; }
+        public IQuery<T> PrimaryQuery { get; set; }
+        public IList<SelectQuery> JoinQueries { get; set; }
+
+        public JoinQuery(Database db, IQuery<T> primary, params SelectQuery[] joinQueries)
+        {
+            this.DB = db;
+            this.PrimaryQuery = primary;
+            this.JoinQueries = joinQueries;
+        }
+
+        public JoinQuery(Database db, IQuery<T> primary, IList<SelectQuery> joinQueries)
+        {
+            this.DB = db;
+            this.PrimaryQuery = primary;
+            this.JoinQueries = joinQueries;
+        }
+
+        public string TableName
+        {
+            get { return this.PrimaryQuery.TableName; }
+            set { this.PrimaryQuery.TableName = value; }
+        }
+
+        public IExpression Where
+        {
+            get { return this.PrimaryQuery.Where; }
+            set { this.PrimaryQuery.Where = value; }
+        }
+
+        public bool RequireMerge
+        {
+            get { return this.PrimaryQuery.RequireMerge; }
+        }
+
+        public void OnBeforeQuery(Table table)
+        {
+            this.PrimaryQuery.OnBeforeQuery(table);
+        }
+
+        public void Correct(ICorrector corrector)
+        {
+            // Correct with the existing correctors
+            this.PrimaryQuery.Correct(corrector);
+
+            // Correct and evaluate any referenced join queries
+            JoinCorrector j = new JoinCorrector(this.DB, corrector, this.JoinQueries);
+            this.PrimaryQuery.Correct(j);
+        }
+
+        public T Compute(Partition p)
+        {
+            return this.PrimaryQuery.Compute(p);
+        }
+
+        public T Merge(T[] partitionResults)
+        {
+            return this.PrimaryQuery.Merge(partitionResults);
+        }
+    }
+}

--- a/Arriba/Arriba/Model/Query/JoinQuery.cs
+++ b/Arriba/Arriba/Model/Query/JoinQuery.cs
@@ -18,6 +18,11 @@ namespace Arriba.Model.Query
     ///  Then correcting 'Q' will cause the JoinCorrector to run Q1, get all
     ///  values for the 'Alias' column, split them, and replace [Members]::#Q1[Alias]
     ///  with [Members]:: IN(alias1, alias2, alias3, ...).
+    ///  
+    ///  NOTE: It's a future goal to allow the nested queries to be more generic than SelectQuery.
+    ///   This requires:
+    ///     - Must be able to set columns, count, and maybe sort order on query.
+    ///     - Must be able to get DataBlock from the result.
     /// </summary>
     public class JoinQuery<T> : IQuery<T>
     {

--- a/Arriba/Arriba/Model/Query/SelectQuery.cs
+++ b/Arriba/Arriba/Model/Query/SelectQuery.cs
@@ -163,7 +163,8 @@ namespace Arriba.Model.Query
 
         public void Correct(ICorrector corrector)
         {
-            if (corrector == null) throw new ArgumentNullException("corrector");
+            // Null corrector means no corrections to make
+            if (corrector == null) return;
 
             this.Where = corrector.Correct(this.Where);
         }
@@ -175,7 +176,7 @@ namespace Arriba.Model.Query
             SelectResult result = new SelectResult(this);
 
             // Verify that the ORDER BY column exists
-            if (!p.Columns.ContainsKey(this.OrderByColumn))
+            if (!String.IsNullOrEmpty(this.OrderByColumn) && !p.Columns.ContainsKey(this.OrderByColumn))
             {
                 result.Details.AddError(ExecutionDetails.ColumnDoesNotExist, this.OrderByColumn);
                 return result;

--- a/Arriba/Arriba/Model/Table.cs
+++ b/Arriba/Arriba/Model/Table.cs
@@ -591,6 +591,11 @@ namespace Arriba.Model
         {
             // Route SelectQuery to the Select API. It has a different flow, but users shouldn't have to know not to call Query with SelectQuery instances.
             if (query is SelectQuery) return (T)(object)this.Select((SelectQuery)query);
+            if (query is JoinQuery<SelectResult>)
+            {
+                SelectQuery q = (SelectQuery)(((JoinQuery<SelectResult>)query).PrimaryQuery);
+                return (T)(object)this.Select(q);
+            }
 
             _locker.EnterReadLock();
             try

--- a/Arriba/Arriba/Serialization/RssWriter.cs
+++ b/Arriba/Arriba/Serialization/RssWriter.cs
@@ -48,7 +48,7 @@ namespace Arriba.Serialization
             WriteTag(linkTag, url);
             WriteTag(lastBuildDateTag, publishedDate.ToString("r"));
             WriteTag(pubDateTag, publishedDate.ToString("r"));
-            WriteTag(ttlTag, timeToLive.TotalSeconds.ToString());
+            WriteTag(ttlTag, timeToLive.TotalMinutes.ToString());
             newline.WriteTo(stream);
         }
 

--- a/Arriba/Arriba/Serialization/UTF8.cs
+++ b/Arriba/Arriba/Serialization/UTF8.cs
@@ -12,6 +12,7 @@ namespace Arriba.Serialization
     /// </summary>
     public static class UTF8
     {
+        public const byte Space = (byte)' ';
         public const byte LF = (byte)10;
         public const byte CR = (byte)13;
         public const byte DoubleQuote = (byte)34;

--- a/Arriba/Tools/Arriba.Csv/Arriba.Csv.csproj
+++ b/Arriba/Tools/Arriba.Csv/Arriba.Csv.csproj
@@ -14,7 +14,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>

--- a/Arriba/Tools/Arriba.Csv/Arriba.Csv.csproj
+++ b/Arriba/Tools/Arriba.Csv/Arriba.Csv.csproj
@@ -14,7 +14,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Arriba/Tools/Arriba.Csv/Program.cs
+++ b/Arriba/Tools/Arriba.Csv/Program.cs
@@ -13,6 +13,7 @@ using Arriba.Model.Column;
 using Arriba.Model.Query;
 using Arriba.Serialization.Csv;
 using Arriba.Structures;
+using System.IO;
 
 namespace Arriba.Csv
 {
@@ -28,9 +29,9 @@ namespace Arriba.Csv
     'decorate' mode used to add new columns to existing rows only.
     'query' to run a query from the command line.
     
-    Arriba.Csv /mode:build /table:<TableName> /csvPath:<CsvFilePath> [/maximumCount:<RowLimitForTable>]? [/columns:""C1,C2,C3""]?
+    Arriba.Csv /mode:build /table:<TableName> /csvPath:<CsvFilePath> [/maximumCount:<RowLimitForTable>]? [/columns:""C1,C2,C3""]? [/schemaPath:<SchemaPath>]?
     Arriba.Csv /mode:query /table:<TableName> [/select:<ColumnList>]? [/orderBy:<ColumnName>]? [/count:<CountToShow>]?
-    Arriba.Csv /mode:decorate /table:<TableName> /csvPath:<CsvFilePath> [/maximumCount:<RowLimitForTable>]? [/columns:""C1,C2,C3""]?
+    Arriba.Csv /mode:decorate /table:<TableName> /csvPath:<CsvFilePath> [/maximumCount:<RowLimitForTable>]? [/columns:""C1,C2,C3""]? [/schemaPath:<SchemaPath>]?
 
     Ex:
       Arriba.Csv /mode:build /table:SP500 /csvPath:""C:\Temp\SP500 Price History.csv"" /maximumCount:50000
@@ -47,10 +48,10 @@ namespace Arriba.Csv
                 switch (mode)
                 {
                     case "build":
-                        Build(true, c.GetString("table"), c.GetString("csvPath"), c.GetInt("maximumCount", 100000), c.GetString("columns", null));
+                        Build(true, c.GetString("table"), c.GetString("csvPath"), c.GetInt("maximumCount", 100000), c.GetString("columns", null), c.GetString("schemaPath", null));
                         break;
                     case "decorate":
-                        Build(false, c.GetString("table"), c.GetString("csvPath"), c.GetInt("maximumCount", 100000), c.GetString("columns", null));
+                        Build(false, c.GetString("table"), c.GetString("csvPath"), c.GetInt("maximumCount", 100000), c.GetString("columns", null), c.GetString("schemaPath", null));
                         break;
                     case "query":
                         Query(c.GetString("table"), c.GetString("select", ""), c.GetString("orderBy", ""), c.GetInt("count", QueryResultLimit));
@@ -75,7 +76,42 @@ namespace Arriba.Csv
             }
         }
 
-        private static void Build(bool build, string tableName, string csvFilePath, int maximumCount, string columns)
+        private static IList<ColumnDetails> ParseSchemaFile(string schemaFilePath)
+        {
+            List<ColumnDetails> columns = new List<ColumnDetails>();
+            foreach (string line in File.ReadAllLines(schemaFilePath))
+            {
+                string[] values = line.Split('\t');
+                ColumnDetails d;
+
+                if (values.Length == 1)
+                {
+                    d = new ColumnDetails(values[0]);
+                }
+                else if (values.Length == 2)
+                {
+                    d = new ColumnDetails(values[0], values[1], null);
+                }
+                else if (values.Length == 3)
+                {
+                    d = new ColumnDetails(values[0], values[1], null);
+                }
+                else if(values.Length == 5)
+                {
+                    d = new ColumnDetails(values[0], values[1], values[2], values[3], bool.Parse(values[4]));
+                }
+                else
+                {
+                    throw new InvalidOperationException(String.Format("Schema Files must be tab delimited, and may contain 1, 2, 3, or 5 values:\r\nName\tType?\tDefault?\tAlias?\tIsPrimaryKey\r\n. Line Read: {0}", line));
+                }
+
+                columns.Add(d);
+            }
+
+            return columns;
+        }
+
+        private static void Build(bool build, string tableName, string csvFilePath, int maximumCount, string columns, string schemaPath = null)
         {
             string action = (build ? "Building" : "Decorating");
 
@@ -94,6 +130,17 @@ namespace Arriba.Csv
             { 
                 table = new Table();
                 table.Load(tableName);
+            }
+
+            // Add schema columns, if given a schema path
+            if (!String.IsNullOrEmpty(schemaPath))
+            {
+                Console.WriteLine("Adding Schema from {0}...", schemaPath);
+                IList<ColumnDetails> schemaColumns = ParseSchemaFile(schemaPath);
+                foreach (ColumnDetails column in schemaColumns)
+                {
+                    table.AddColumn(column);
+                }
             }
 
             // Always add missing columns. Add rows only when not in 'decorate' mode


### PR DESCRIPTION
@dannychenmsft @rtaket @michaelcfanning I'm experimenting with implementing Joins via a corrector, which replaces the value of a term like "AllAdminUsers:#Q1[Alias]" with the values found by running the "Q1" query against the "T1" table and then getting all values for alias. I already had TermInQuery, which handles largeish "IN" queries efficiently, and correctors handle the replacement smoothly.
