### PR TITLE
SelectQuery Total Fix, Test; AggregationQuery default column

### DIFF
--- a/Arriba/Arriba.Test/Model/TableTests.cs
+++ b/Arriba/Arriba.Test/Model/TableTests.cs
@@ -443,6 +443,17 @@ namespace Arriba.Test.Model
             Assert.AreEqual("11999", result.Values[0, 0].ToString());
             Assert.AreEqual("11643", result.Values[1, 0].ToString());
 
+            // Ask for only one item; verify one returned, total still correct
+            query.Count = 1;
+            query.OrderByColumn = "ID";
+            query.OrderByDescending = true;
+            result = table.Query(query);
+            Assert.AreEqual(2, (int)result.Total);
+            Assert.AreEqual(1, (int)result.CountReturned);
+            Assert.AreEqual(1, (int)result.Values.RowCount);
+            Assert.AreEqual("11999", result.Values[0, 0].ToString());
+            query.Count = 3;
+
             // Select a word in first item (cover a simple search and zero-LID handling)
             SelectQuery q2 = new SelectQuery();
             q2.Columns = new string[] { "ID" };
@@ -943,7 +954,7 @@ Title:unused, null
             query.Count = 5;
             SelectResult result = table.Query(query);
 
-            Assert.AreEqual(5, (int)result.Total);
+            Assert.AreEqual(5, (int)result.CountReturned);
         }
 
         internal static void AddColumns(ITable table)

--- a/Arriba/Arriba/Model/Query/AggregationQuery.cs
+++ b/Arriba/Arriba/Model/Query/AggregationQuery.cs
@@ -132,6 +132,11 @@ namespace Arriba.Model.Query
         public virtual void OnBeforeQuery(Table table)
         {
             this.Where = this.Where ?? new AllExpression();
+
+            if(this.AggregationColumns.Length == 0 || (this.AggregationColumns.Length == 1 && this.AggregationColumns[0] == "*"))
+            {
+                this.AggregationColumns = new string[] { table.IDColumn.Name };
+            }
         }
 
         public bool RequireMerge

--- a/Arriba/Arriba/Model/Query/AggregationQuery.cs
+++ b/Arriba/Arriba/Model/Query/AggregationQuery.cs
@@ -133,7 +133,7 @@ namespace Arriba.Model.Query
         {
             this.Where = this.Where ?? new AllExpression();
 
-            if(this.AggregationColumns.Length == 0 || (this.AggregationColumns.Length == 1 && this.AggregationColumns[0] == "*"))
+            if(this.AggregationColumns != null && (this.AggregationColumns.Length == 0 || (this.AggregationColumns.Length == 1 && this.AggregationColumns[0] == "*")))
             {
                 this.AggregationColumns = new string[] { table.IDColumn.Name };
             }

--- a/Arriba/Arriba/Model/Query/SelectQuery.cs
+++ b/Arriba/Arriba/Model/Query/SelectQuery.cs
@@ -468,7 +468,15 @@ namespace Arriba.Model.Query
                     mergedResult.Details.Merge(partitionResults[i].Details);
                 }
 
-                mergedResult.Total = totalFound;
+                if (this.Pass1Results == null)
+                {
+                    mergedResult.Total = totalFound;
+                }
+                else
+                {
+                    mergedResult.Total = this.Pass1Results.Total;
+                }
+
                 mergedResult.CountReturned = (ushort)Math.Min(this.Count, totalReturned);
 
                 if (mergedResult.Details.Succeeded)


### PR DESCRIPTION
- Fix SelectQuery total, which returned only CountReturned even if total was larger.
- Added test coverage.
- Fix to allow asking for "COUNT(*)" correction on the service.