### PR TITLE
Fix highlighting and query round-trip with column restrictions

### DIFF
--- a/Arriba/Arriba/Extensions/IExpressionExtensions.cs
+++ b/Arriba/Arriba/Extensions/IExpressionExtensions.cs
@@ -26,7 +26,12 @@ namespace Arriba.Extensions
 
         private static void GetAllTerms(IExpression expression, string columnName, List<TermExpression> result)
         {
-            if (expression is TermExpression)
+            if(expression is AllExceptColumnsTermExpression)
+            {
+                AllExceptColumnsTermExpression te = (AllExceptColumnsTermExpression)expression;
+                if (!te.RestrictedColumns.Contains(columnName)) result.Add(te);
+            }
+            else if (expression is TermExpression)
             {
                 TermExpression te = (TermExpression)expression;
 

--- a/Arriba/Arriba/Model/Expressions/Expressions.cs
+++ b/Arriba/Arriba/Model/Expressions/Expressions.cs
@@ -206,7 +206,7 @@ namespace Arriba.Model.Expressions
             this.Value = Value.Create(value);
         }
 
-        public void TryEvaluate(Partition partition, ShortSet result, ExecutionDetails details)
+        public virtual void TryEvaluate(Partition partition, ShortSet result, ExecutionDetails details)
         {
             if (details == null) throw new ArgumentNullException("details");
             if (result == null) throw new ArgumentNullException("result");
@@ -257,24 +257,21 @@ namespace Arriba.Model.Expressions
         }
     }
 
-    public class AllExceptColumnsTermExpression : IExpression
+    public class AllExceptColumnsTermExpression : TermExpression
     {
         public HashSet<string> RestrictedColumns;
-        public Operator Operator;
-        public Value Value;
 
-        public AllExceptColumnsTermExpression(HashSet<string> restrictedColumns, Operator op, Value value)
+        public AllExceptColumnsTermExpression(HashSet<string> restrictedColumns, Operator op, Value value) :
+            base("*", op, value)
         {
             this.RestrictedColumns = restrictedColumns;
-            this.Operator = op;
-            this.Value = value;
         }
 
         public AllExceptColumnsTermExpression(HashSet<string> restrictedColumns, TermExpression previousExpression) :
             this(restrictedColumns, previousExpression.Operator, previousExpression.Value)
         { }
 
-        public void TryEvaluate(Partition partition, ShortSet result, ExecutionDetails details)
+        public override void TryEvaluate(Partition partition, ShortSet result, ExecutionDetails details)
         {
             if (details == null) throw new ArgumentNullException("details");
             if (result == null) throw new ArgumentNullException("result");
@@ -301,11 +298,6 @@ namespace Arriba.Model.Expressions
             {
                 details.Merge(perColumnDetails);
             }
-        }
-
-        public IList<IExpression> Children()
-        {
-            return EmptyExpression.EmptyEnumerable;
         }
 
         public override string ToString()

--- a/Arriba/Arriba/Model/Expressions/Expressions.cs
+++ b/Arriba/Arriba/Model/Expressions/Expressions.cs
@@ -299,11 +299,6 @@ namespace Arriba.Model.Expressions
                 details.Merge(perColumnDetails);
             }
         }
-
-        public override string ToString()
-        {
-            return StringExtensions.Format("~*{0}{1}", this.Operator.ToSyntaxString(), QueryScanner.WrapValue(this.Value.ToString()));
-        }
     }
 
     public class TermInExpression : IExpression

--- a/Elfie/Elfie/Serialization/BaseTabularReader.cs
+++ b/Elfie/Elfie/Serialization/BaseTabularReader.cs
@@ -33,12 +33,12 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
     ///     int descriptionIndex = r.ColumnIndex("Description");
     ///     int itemTypeIndex = r.ColumnIndex("ItemType");
     ///
-    ///     // Use NextRow() and CurrentRow(index) to read values
+    ///     // Use NextRow() and Current[index] to read values
     ///     while (r.NextRow())
     ///     {
-    ///         String8 title = r.CurrentRow(titleIndex);
-    ///         String8 description = r.CurrentRow(descriptionIndex);
-    ///         int itemType = r.CurrentRow(itemTypeIndex).ToInteger();
+    ///         String8 title = r.Current[titleIndex];
+    ///         String8 description = r.Current[descriptionIndex];
+    ///         int itemType = r.Current[itemTypeIndex].ToInteger();
     ///         
     ///         // COPY String8s to be kept
     ///     }


### PR DESCRIPTION
Fixing UX regressions with column security - I need the highlighter to recognize AllColumnsExceptTermExpression and I need to return a ToString value for the expressions which parses when passed back as a query again.