### PR TITLE
- AggregationQuery: Don't correct empty columns to ID column. Fix cod…

### DIFF
--- a/Arriba/Arriba.Client/Model/SecureDatabase.cs
+++ b/Arriba/Arriba.Client/Model/SecureDatabase.cs
@@ -160,13 +160,16 @@ namespace Arriba.Model
             else if (primaryQuery.GetType().Equals(typeof(AggregationQuery)))
             {
                 AggregationQuery aq = (AggregationQuery)primaryQuery;
-                foreach (string columnName in aq.AggregationColumns)
+                if (aq.AggregationColumns != null)
                 {
-                    if (restrictedColumns.Contains(columnName))
+                    foreach (string columnName in aq.AggregationColumns)
                     {
-                        details.AddDeniedColumn(columnName);
-                        details.AddError(ExecutionDetails.DisallowedColumnQuery, columnName);
-                        aq.Where = new EmptyExpression();
+                        if (restrictedColumns.Contains(columnName))
+                        {
+                            details.AddDeniedColumn(columnName);
+                            details.AddError(ExecutionDetails.DisallowedColumnQuery, columnName);
+                            aq.Where = new EmptyExpression();
+                        }
                     }
                 }
             }

--- a/Arriba/Arriba.Communication/Server/Application/ArribaQueryApplication.cs
+++ b/Arriba/Arriba.Communication/Server/Application/ArribaQueryApplication.cs
@@ -289,7 +289,7 @@ namespace Arriba.Server
             List<CountResult> results = new List<CountResult>();
 
             // Build a Count query
-            IQuery<AggregationResult> query = new AggregationQuery("count", new string[0], ctx.Request.ResourceParameters["q"] ?? "");
+            IQuery<AggregationResult> query = new AggregationQuery("count", null, ctx.Request.ResourceParameters["q"] ?? "");
 
             // Wrap in Joins, if found
             query = WrapInJoinQueryIfFound(query, this.Database, ctx);
@@ -411,7 +411,7 @@ namespace Arriba.Server
 
             AggregationQuery query = new AggregationQuery();
             query.Aggregator = AggregationQuery.BuildAggregator(aggregationFunction);
-            query.AggregationColumns = new string[] { columnName };
+            query.AggregationColumns = String.IsNullOrEmpty(columnName) ? null : new string[] { columnName };
             query.Where = whereExpression;
 
             foreach (string dimension in dimensions)

--- a/Arriba/Arriba/Model/Query/AggregationQuery.cs
+++ b/Arriba/Arriba/Model/Query/AggregationQuery.cs
@@ -64,7 +64,7 @@ namespace Arriba.Model.Query
             : this()
         {
             this.Aggregator = BuildAggregator(aggregationFunction);
-            this.AggregationColumns = new List<string>(columns).ToArray();
+            this.AggregationColumns = columns == null ? null : new List<string>(columns).ToArray();
             this.Where = QueryParser.Parse(where);
         }
 
@@ -132,11 +132,6 @@ namespace Arriba.Model.Query
         public virtual void OnBeforeQuery(Table table)
         {
             this.Where = this.Where ?? new AllExpression();
-
-            if(this.AggregationColumns != null && (this.AggregationColumns.Length == 0 || (this.AggregationColumns.Length == 1 && this.AggregationColumns[0] == "*")))
-            {
-                this.AggregationColumns = new string[] { table.IDColumn.Name };
-            }
         }
 
         public bool RequireMerge


### PR DESCRIPTION
…e to not require a column at all for count.

- Fix Arriba.Communication not to build an array with a single null value when constructing an AggregationQuery from a request.
- Fix SecureDatabase to handle no columns to secure in AggregationQuery.