### PR TITLE
DistinctQuery Fixes

### DIFF
--- a/Arriba/Arriba.Client/Model/Security/SecurityPermissions.cs
+++ b/Arriba/Arriba.Client/Model/Security/SecurityPermissions.cs
@@ -4,15 +4,22 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 
 using Arriba.Serialization;
 using Newtonsoft.Json;
 
 namespace Arriba.Model.Security
 {
-    [JsonArray]
+    [JsonArray, Serializable]
     public class SecuredSet<T> : Dictionary<SecurityIdentity, T>
-    { }
+    {
+        public SecuredSet() : base()
+        { }
+
+        protected SecuredSet(SerializationInfo info, StreamingContext context) : base(info, context)
+        { }
+    }
 
     /// <summary>
     /// Represents access permissions to a resource. 

--- a/Arriba/Arriba.Communication/Server/Application/ArribaQueryApplication.cs
+++ b/Arriba/Arriba.Communication/Server/Application/ArribaQueryApplication.cs
@@ -348,7 +348,7 @@ namespace Arriba.Server
             }
         }
 
-        private async Task<IResponse> Query<T>(IRequestContext ctx, Route route, IQuery<T> query)
+        private IResponse Query<T>(IRequestContext ctx, Route route, IQuery<T> query)
         {
             IQuery<T> wrappedQuery = WrapInJoinQueryIfFound(query, this.Database, ctx);
 
@@ -378,7 +378,7 @@ namespace Arriba.Server
         private async Task<IResponse> Aggregate(IRequestContext ctx, Route route)
         {
             IQuery<AggregationResult> query = await BuildAggregateFromContext(ctx);
-            return await Query(ctx, route, query);
+            return Query(ctx, route, query);
         }
 
         private static async Task<AggregationQuery> BuildAggregateFromContext(IRequestContext ctx)
@@ -422,7 +422,7 @@ namespace Arriba.Server
         private async Task<IResponse> Distinct(IRequestContext ctx, Route route)
         {
             IQuery<DistinctResult> query = await BuildDistinctFromContext(ctx);
-            return await Query(ctx, route, query);
+            return Query(ctx, route, query);
         }
 
         private async static Task<DistinctQuery> BuildDistinctFromContext(IRequestContext ctx)

--- a/Arriba/Arriba.Query/DistinctValueDimension.cs
+++ b/Arriba/Arriba.Query/DistinctValueDimension.cs
@@ -26,9 +26,17 @@ namespace Arriba.Model.Query
 
             var result = table.Query(distinctQuery);
 
-            for (var i = 0; i < result.Values.RowCount; i++)
+            if (result.Details.Succeeded)
             {
-                this.AddCondition(StringExtensions.Format("[{0}]=\"{1}\"", this.Column, result.Values[i, 0]));
+                for (var i = 0; i < result.Values.RowCount; i++)
+                {
+                    this.AddCondition(StringExtensions.Format("[{0}]=\"{1}\"", this.Column, result.Values[i, 0]));
+                }
+            }
+            else
+            {
+                // If the column doesn't exist or the query fails, add one dimension value so the overall AggregationQuery will return a good error
+                this.AddCondition(StringExtensions.Format("[{0}]=\"\"", this.Column));
             }
         }
     }

--- a/Arriba/Arriba.Test/CustomColumn.cs
+++ b/Arriba/Arriba.Test/CustomColumn.cs
@@ -167,6 +167,16 @@ namespace Arriba.Test
                 return false;
             }
 
+            public static bool operator==(ComparableColor left, ComparableColor right)
+            {
+                return left.ColorValue == right.ColorValue;
+            }
+
+            public static bool operator!=(ComparableColor left, ComparableColor right)
+            {
+                return left.ColorValue != right.ColorValue;
+            }
+
             public override int GetHashCode()
             {
                 return this.ColorValue.GetHashCode();

--- a/Arriba/Arriba.Test/Indexing/DefaultWordSplitterTests.cs
+++ b/Arriba/Arriba.Test/Indexing/DefaultWordSplitterTests.cs
@@ -5,10 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 
-using Arriba.Diagnostics;
 using Arriba.Extensions;
 using Arriba.Indexing;
 using Arriba.Structures;
@@ -20,7 +18,7 @@ namespace Arriba.Test.Indexing
     [TestClass]
     public class DefaultWordSplitterTests : WordSplitterTestBase
     {
-        private const string filePath = @"..\..\..\Arriba\Model\Table.cs";
+        private const string SampleFilePath = @"..\..\Arriba\Model\Table.cs";
 
         public DefaultWordSplitterTests() :
             base(new DefaultWordSplitter())
@@ -51,7 +49,7 @@ namespace Arriba.Test.Indexing
             Stopwatch w = Stopwatch.StartNew();
             Trace.WriteLine("Splitting all bug strings (compare)");
 
-            using (System.IO.StreamReader reader = new System.IO.StreamReader(filePath))
+            using (System.IO.StreamReader reader = new System.IO.StreamReader(SampleFilePath))
             {
                 // 100ms just reading
                 string line;
@@ -100,7 +98,7 @@ namespace Arriba.Test.Indexing
             Stopwatch w = Stopwatch.StartNew();
             Trace.WriteLine("Splitting all bug strings (compare)");
 
-            using (System.IO.StreamReader reader = new System.IO.StreamReader(filePath))
+            using (System.IO.StreamReader reader = new System.IO.StreamReader(SampleFilePath))
             {
                 byte[] buffer = new byte[8 * 1024];
 
@@ -145,7 +143,7 @@ namespace Arriba.Test.Indexing
             Stopwatch w = Stopwatch.StartNew();
             Trace.WriteLine("Splitting all bug strings (compare)");
 
-            Parallel.ForEach(ReadBlocks(filePath), (buffer) =>
+            Parallel.ForEach(ReadBlocks(SampleFilePath), (buffer) =>
             {
                 // Wrong - need to figure out how to tell.
                 int length = 8 * 1024;//reader.BaseStream.Read(buffer, 0, buffer.Length);

--- a/Arriba/Arriba/Model/Query/DistinctQuery.cs
+++ b/Arriba/Arriba/Model/Query/DistinctQuery.cs
@@ -115,6 +115,7 @@ namespace Arriba.Model.Query
         {
             if (partitionResults == null) throw new ArgumentNullException("partitionResults");
             if (partitionResults.Length == 0) throw new ArgumentException("Length==0 not supported", "partitionResults");
+            if (!partitionResults[0].Details.Succeeded) return partitionResults[0];
 
             DistinctResult mergedResult = new DistinctResult(this);
             mergedResult.ColumnType = partitionResults[0].ColumnType;

--- a/Arriba/Arriba/Model/Query/DistinctQuery.cs
+++ b/Arriba/Arriba/Model/Query/DistinctQuery.cs
@@ -178,7 +178,56 @@ namespace Arriba.Model.Query
         {
             public override Array GetUniqueValuesFromColumn(IColumn column, ShortSet whereSet, int count, out bool allValuesReturned)
             {
+                if(count <= 0)
+                {
+                    allValuesReturned = false;
+                    return new T[0];
+                }
+                
                 IColumn<T> typedColumn = (IColumn<T>)column;
+
+                // Boolean columns aren't sorted - just check true and false
+                if(typedColumn is BooleanColumn)
+                {
+                    int countBefore = whereSet.Count();
+                    if(countBefore == 0)
+                    {
+                        allValuesReturned = true;
+                        return new bool[0];
+                    }
+
+                    // Filter to the set of values with the column 'true'
+                    BooleanColumn bc = (BooleanColumn)typedColumn;
+                    ShortSet trueSet = new ShortSet(bc.Count);
+                    bc.TryWhere(Operator.Equals, true, trueSet, null);
+                    whereSet.And(trueSet);
+
+                    // Determine the count which were true and false matching the query
+                    int countWhichAreTrue = whereSet.Count();
+                    int countWhichAreFalse = countBefore - countWhichAreTrue;
+
+                    allValuesReturned = true;
+
+                    if (countWhichAreTrue > 0 && countWhichAreFalse > 0)
+                    {
+                        // If both existed and only one value was requested, return the value which more items had
+                        if(count == 1)
+                        {
+                            allValuesReturned = false;
+                            return new bool[] { (countWhichAreTrue > countWhichAreFalse) };
+                        }
+                        
+                        return new bool[] { true, false };
+                    }
+                    else if (countWhichAreTrue > 0)
+                    {
+                        return new bool[] { true };
+                    }
+                    else
+                    {
+                        return new bool[] { false };
+                    }
+                }
 
                 // Get all LIDs in sorted order
                 IList<ushort> sortedIndexes;


### PR DESCRIPTION
- Fix DistinctQuery to not throw if column requested is unknown.
- Fix DistinctValueDimension not to throw if DistinctValueQuery fails (unknown column, column security, etc).
- Fix DistinctQuery to work for boolean columns.
- Fix Code Analysis warnings
- Fix WordSplitterTest sample file relative path.