### PR TITLE
December Fixes

### DIFF
--- a/Elfie/Elfie/Model/Map/ImmutableItemMap.cs
+++ b/Elfie/Elfie/Model/Map/ImmutableItemMap.cs
@@ -66,6 +66,14 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Map
             }
         }
 
+        /// <summary>
+        ///  Return the count of links in the Map (so far)
+        /// </summary>
+        public int Count
+        {
+            get { return this._memberIndices.Count; }
+        }
+
         #region IBinarySerializable
         public void ReadBinary(BinaryReader r)
         {

--- a/Elfie/Elfie/Model/Map/ItemMap.cs
+++ b/Elfie/Elfie/Model/Map/ItemMap.cs
@@ -49,6 +49,17 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Map
             return this._immutableMap.LinksFrom(sourceItemIndex);
         }
 
+        public int Count
+        {
+            get
+            {
+                int total = 0;
+                if (this._immutableMap != null) total += this._immutableMap.Count;
+                if (this._mutableMap != null) total += this._mutableMap.Count;
+                return total;
+            }
+        }
+
         #region IColumn
         public void Clear()
         {

--- a/Elfie/Elfie/Model/Map/ItemMap.cs
+++ b/Elfie/Elfie/Model/Map/ItemMap.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Map
         /// <param name="memberIndex">Index of item to which to link</param>
         public void AddLink(int groupIndex, int memberIndex)
         {
-            if (this._mutableMap == null) throw new InvalidOperationException();
+            if (this._mutableMap == null) this._mutableMap = new MutableItemMap<T>(this._provider);
             this._mutableMap.AddLink(groupIndex, memberIndex);
         }
 
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Map
         public void Clear()
         {
             this._immutableMap = null;
-            this._mutableMap = new MutableItemMap<T>(this._provider);
+            this._mutableMap = null;
         }
 
         public void AddItem()
@@ -75,6 +75,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Map
 
         public void ReadBinary(BinaryReader r)
         {
+            this._mutableMap = null;
             this._immutableMap = new ImmutableItemMap<T>(this._provider);
             this._immutableMap.ReadBinary(r);
         }

--- a/Elfie/Elfie/Model/Map/MutableItemMap.cs
+++ b/Elfie/Elfie/Model/Map/MutableItemMap.cs
@@ -70,5 +70,13 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Map
 
             return newMap;
         }
+
+        /// <summary>
+        ///  Return the count of links in the Map (so far)
+        /// </summary>
+        public int Count
+        {
+            get { return this._memberIndices.Count; }
+        }
     }
 }

--- a/Elfie/Elfie/Serialization/BaseTabularReader.cs
+++ b/Elfie/Elfie/Serialization/BaseTabularReader.cs
@@ -118,14 +118,19 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
         ///  Column names are case insensitive.
         ///  Will throw if the column name wasn't found.
         /// </summary>
-        /// <param name="columnName">Column name for which to find column index</param>
+        /// <param name="columnNameOrIndex">Column name for which to find column index, or already an integer index</param>
         /// <returns>Index of column in TSV. Throws if column isn't found or no header row was read.</returns>
-        public int ColumnIndex(string columnName)
+        public int ColumnIndex(string columnNameOrIndex)
         {
             int columnIndex = 0;
-            if (_columnHeadings.TryGetValue(columnName, out columnIndex)) return columnIndex;
 
-            throw new ColumnNotFoundException(String.Format("Column Name \"{0}\" not found in file.\nKnown Columns: \"{1}\"", columnName, String.Join(", ", _columnHeadings.Keys)));
+            // Try to find the column as a name
+            if (_columnHeadings.TryGetValue(columnNameOrIndex, out columnIndex)) return columnIndex;
+
+            // See if the column is a parsable integer index
+            if (int.TryParse(columnNameOrIndex, out columnIndex) && _columnHeadings.Count > columnIndex) return columnIndex;
+
+            throw new ColumnNotFoundException(String.Format("Column Name \"{0}\" not found in file.\nKnown Columns: \"{1}\"", columnNameOrIndex, String.Join(", ", _columnHeadings.Keys)));
         }
 
         /// <summary>


### PR DESCRIPTION
- Arriba: Allow reading parameters separately as a set (C1=A&C2=B&C3=C) rather than a comma-delimited list (cols=A,B,C), to safely send column names with delimiters in them.
- Elfie.BaseTabularReader: Allow looking up columns transparently by name or index, so simplify requesting action by column from tools.
- Elfie.ItemMap: Exposing Count.