### PR TITLE
Update System.Reflection.Metadata reference.

### DIFF
--- a/Elfie/Elfie.EndToEnd/App.config
+++ b/Elfie/Elfie.EndToEnd/App.config
@@ -14,11 +14,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Elfie/Elfie.EndToEnd/Elfie.EndToEnd.csproj
+++ b/Elfie/Elfie.EndToEnd/Elfie.EndToEnd.csproj
@@ -47,14 +47,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0-rc3-23811\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/Elfie/Elfie.EndToEnd/packages.config
+++ b/Elfie/Elfie.EndToEnd/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections" version="4.0.0" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net46" />
   <package id="System.Globalization" version="4.0.0" targetFramework="net46" />
   <package id="System.Linq" version="4.0.0" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.2.0-rc3-23811" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net46" />

--- a/Elfie/Elfie.Indexer/App.config
+++ b/Elfie/Elfie.Indexer/App.config
@@ -14,11 +14,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
 	<appSettings>
-		<add key="SymbolCachePath" value="%SystemDrive%\SymbolCache"/>
+		<add key="SymbolCachePath" value="%SystemDrive%\SymbolCache" />
 	</appSettings>
 </configuration>

--- a/Elfie/Elfie.Indexer/Crawlers/SrmCrawler.cs
+++ b/Elfie/Elfie.Indexer/Crawlers/SrmCrawler.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata;
-using System.Reflection.Metadata.Decoding;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text;
@@ -247,7 +246,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Indexer.Crawlers
 
             StringSignatureProvider provider = new StringSignatureProvider(mdReader, mdReader.GetTypeDefinition(method.GetDeclaringType()), method);
 
-            MethodSignature<string> signature = method.DecodeSignature<string>(provider);
+            MethodSignature<string> signature = method.DecodeSignature<string, DisassemblingGenericContext>(provider, null);
             foreach (string value in signature.ParameterTypes)
             {
                 if (parameterString.Length > 0) parameterString.Append(", ");

--- a/Elfie/Elfie.Indexer/Crawlers/StringSignatureProvider.cs
+++ b/Elfie/Elfie.Indexer/Crawlers/StringSignatureProvider.cs
@@ -307,8 +307,6 @@ namespace Microsoft.CodeAnalysis.Elfie.Indexer.Crawlers
             builder.Append(')');
             return builder.ToString();
         }
-
-        
     }
 
     public static class MissingExtensions

--- a/Elfie/Elfie.Indexer/Elfie.Api.Indexer.csproj
+++ b/Elfie/Elfie.Indexer/Elfie.Api.Indexer.csproj
@@ -83,8 +83,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
@@ -112,9 +113,9 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0-rc3-23728\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />

--- a/Elfie/Elfie.Indexer/packages.config
+++ b/Elfie/Elfie.Indexer/packages.config
@@ -12,11 +12,11 @@
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
   <package id="Microsoft.DiaSymReader" version="1.0.6" targetFramework="net46" />
   <package id="System.Collections" version="4.0.0" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net46" />
   <package id="System.Globalization" version="4.0.0" targetFramework="net46" />
   <package id="System.Linq" version="4.0.0" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.2.0-rc3-23728" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net46" />

--- a/Elfie/Elfie.NonCore.Test/App.config
+++ b/Elfie/Elfie.NonCore.Test/App.config
@@ -4,11 +4,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Elfie/Elfie.Search/App.config
+++ b/Elfie/Elfie.Search/App.config
@@ -15,11 +15,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Elfie/Elfie.Search/Elfie.Search.csproj
+++ b/Elfie/Elfie.Search/Elfie.Search.csproj
@@ -97,8 +97,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -128,9 +129,9 @@
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0-rc3-23728\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/Elfie/Elfie.Search/packages.config
+++ b/Elfie/Elfie.Search/packages.config
@@ -13,14 +13,14 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="Sarif.Sdk" version="1.4.28-beta" targetFramework="net46" />
   <package id="System.Collections" version="4.0.0" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net46" />
   <package id="System.Globalization" version="4.0.0" targetFramework="net46" />
   <package id="System.IO" version="4.0.0" targetFramework="net46" />
   <package id="System.Linq" version="4.0.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.2.0-rc3-23728" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net46" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net46" />

--- a/Elfie/Elfie.Test/Elfie.Test.csproj
+++ b/Elfie/Elfie.Test/Elfie.Test.csproj
@@ -70,7 +70,6 @@
     <Compile Include="Extensions\SampleSerializable.cs" />
     <Compile Include="Extensions\StringExtensionsTests.cs" />
     <Compile Include="Model\AddReferenceDatabaseTests.cs" />
-    <Compile Include="Model\Column\IColumnTests.cs" />
     <Compile Include="Model\Index\MemberIndexTests.cs" />
     <Compile Include="Model\Map\ItemMapTests.cs" />
     <Compile Include="Model\MergedMembersDatabaseTests.cs" />
@@ -87,7 +86,6 @@
     <Compile Include="SampleElfieStructure.V1.cs" />
     <Compile Include="SampleElfieStructure.cs" />
     <Compile Include="Serialization\BaseTabularTests.cs" />
-    <Compile Include="Serialization\ITabularValueTests.cs" />
     <Compile Include="Serialization\TsvWriterTests.cs" />
     <Compile Include="Verify.cs" />
   </ItemGroup>

--- a/Elfie/Elfie.Test/Elfie.Test.csproj
+++ b/Elfie/Elfie.Test/Elfie.Test.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Extensions\SampleSerializable.cs" />
     <Compile Include="Extensions\StringExtensionsTests.cs" />
     <Compile Include="Model\AddReferenceDatabaseTests.cs" />
+    <Compile Include="Model\Column\IColumnTests.cs" />
     <Compile Include="Model\Index\MemberIndexTests.cs" />
     <Compile Include="Model\Map\ItemMapTests.cs" />
     <Compile Include="Model\MergedMembersDatabaseTests.cs" />
@@ -86,6 +87,7 @@
     <Compile Include="SampleElfieStructure.V1.cs" />
     <Compile Include="SampleElfieStructure.cs" />
     <Compile Include="Serialization\BaseTabularTests.cs" />
+    <Compile Include="Serialization\ITabularValueTests.cs" />
     <Compile Include="Serialization\TsvWriterTests.cs" />
     <Compile Include="Verify.cs" />
   </ItemGroup>

--- a/Elfie/SymbolSourceGet/App.config
+++ b/Elfie/SymbolSourceGet/App.config
@@ -1,17 +1,29 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
   </startup>
   <system.diagnostics>
     <trace autoflush="true" indentsize="4">
       <listeners>
-        <add name="consoleListener" type="System.Diagnostics.ConsoleTraceListener"/>
+        <add name="consoleListener" type="System.Diagnostics.ConsoleTraceListener" />
       </listeners>
     </trace>
   </system.diagnostics>
   <appSettings>
-    <add key="SymbolServerUrls" value="http://referencesource.microsoft.com/symbols|http://msdl.microsoft.com/download/symbols|https://nuget.smbsrc.net"/>
-    <add key="SymbolCachePath" value="%SystemDrive%\SymbolCache"/>
+    <add key="SymbolServerUrls" value="http://referencesource.microsoft.com/symbols|http://msdl.microsoft.com/download/symbols|https://nuget.smbsrc.net" />
+    <add key="SymbolCachePath" value="%SystemDrive%\SymbolCache" />
   </appSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Elfie/SymbolSourceGet/SymbolSourceGet.csproj
+++ b/Elfie/SymbolSourceGet/SymbolSourceGet.csproj
@@ -40,15 +40,16 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0-rc3-23728\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/Elfie/SymbolSourceGet/packages.config
+++ b/Elfie/SymbolSourceGet/packages.config
@@ -2,11 +2,11 @@
 <packages>
   <package id="CommandLineParser" version="2.0.275-beta" targetFramework="net46" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net452" />
   <package id="System.Globalization" version="4.0.0" targetFramework="net452" />
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.2.0-rc3-23728" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net452" />


### PR DESCRIPTION
   - Updating to the current release (the old version was removed from NuGet)
   - Updating StringSignatureProvider to match final ISignatureTypeProvider design (following the pattern of the test file in the class comment).