### PR TITLE
DataBlock projections for AddOrUpdate

### DIFF
--- a/Arriba/Arriba.Communication/Server/Application/ArribaImportApplication.cs
+++ b/Arriba/Arriba.Communication/Server/Application/ArribaImportApplication.cs
@@ -77,7 +77,7 @@ namespace Arriba.Server.Application
                     foreach (var blockBatch in reader.ReadAsDataBlockBatch(BatchSize))
                     {
                         response.RowCount += blockBatch.RowCount;
-                        table.AddOrUpdate(blockBatch);
+                        table.AddOrUpdate(blockBatch.AsReadOnly());
                     }
                 }
             }
@@ -98,7 +98,7 @@ namespace Arriba.Server.Application
             using (ctx.Monitor(MonitorEventLevel.Information, "Import.DataBlock", type: "Table", identity: tableName))
             {
                 DataBlock block = await ctx.Request.ReadBodyAsync<DataBlock>();
-                table.AddOrUpdate(block);
+                table.AddOrUpdate(block.AsReadOnly());
 
                 ImportResponse response = new ImportResponse();
                 response.TableName = tableName;
@@ -183,7 +183,7 @@ namespace Arriba.Server.Application
                         }
                     }
 
-                    table.AddOrUpdate(block);
+                    table.AddOrUpdate(block.AsReadOnly());
                 }
 
                 using (ctx.Monitor(MonitorEventLevel.Verbose, "table.save"))

--- a/Arriba/Arriba.Test/Model/AggregatorTests.cs
+++ b/Arriba/Arriba.Test/Model/AggregatorTests.cs
@@ -150,7 +150,7 @@ namespace Arriba.Test.Model
             // Add to a table with the desired column type, big enough to have multiple partitions
             Table table = new Table("Sample", 100000);
             table.AddColumn(new ColumnDetails("ID", columnType, null, "", true));
-            table.AddOrUpdate(block);
+            table.AddOrUpdate(block.AsReadOnly());
 
             // Build an AggregationQuery
             AggregationQuery q = new AggregationQuery();

--- a/Arriba/Arriba.Test/Model/Correctors/ExpressionCorrectorTests.cs
+++ b/Arriba/Arriba.Test/Model/Correctors/ExpressionCorrectorTests.cs
@@ -77,7 +77,7 @@ namespace Arriba.Test.Model.Correctors
                 }
             );
 
-            people.AddOrUpdate(block, new AddOrUpdateOptions() { AddMissingColumns = true });
+            people.AddOrUpdate(block.AsReadOnly(), new AddOrUpdateOptions() { AddMissingColumns = true });
 
             UserAliasCorrector corrector = new UserAliasCorrector(people);
 

--- a/Arriba/Arriba.Test/Model/DatabaseTests.cs
+++ b/Arriba/Arriba.Test/Model/DatabaseTests.cs
@@ -28,7 +28,7 @@ namespace Arriba.Test.Model
                     new string[] { "Michael Fanning", "Ryley Taketa", "Scott Louvau"},
                     new string[] { "T1", "T1", "T2" },
                     new string[] { "G1; G2", "G1; G3", "G4" }
-                }), new AddOrUpdateOptions() { AddMissingColumns = true });
+                }).AsReadOnly(), new AddOrUpdateOptions() { AddMissingColumns = true });
 
             Table orders = db.AddTable("Orders", 1000);
             orders.AddOrUpdate(new DataBlock(new string[] { "OrderNumber", "OrderedByAlias" }, 6,
@@ -36,7 +36,7 @@ namespace Arriba.Test.Model
                 {
                     new string[] { "O1", "O2", "O3", "O4", "O5", "O6" },
                     new string[] { "mikefan", "mikefan", "rtaket", "v-scolo", "rtaket", "mikefan; rtaket" }
-                }), new AddOrUpdateOptions() { AddMissingColumns = true });
+                }).AsReadOnly(), new AddOrUpdateOptions() { AddMissingColumns = true });
 
             SelectResult result;
 

--- a/Arriba/Arriba.Test/Model/SecureDatabaseTests.cs
+++ b/Arriba/Arriba.Test/Model/SecureDatabaseTests.cs
@@ -38,7 +38,7 @@ namespace Arriba.Test.Model
                     new string[] { "Bob", "Alice", "Alice", "Bob", "Bob" },
                     new byte[] { 3, 3, 2, 2, 0 }
                 });
-            t.AddOrUpdate(b);
+            t.AddOrUpdate(b.AsReadOnly());
 
             return db;
         }

--- a/Arriba/Arriba.Test/Model/TableTests.cs
+++ b/Arriba/Arriba.Test/Model/TableTests.cs
@@ -94,10 +94,10 @@ namespace Arriba.Test.Model
 
             // Get sample items but ask the partition only to add some of them
             DataBlock block = BuildSampleData();
-            int[] partitionChains = new int[] { 1, -1, 3, 4, -1 };
-            int[] partitionChainHeads = new int[] { 0, 2 };
+            int[] itemIndexes = new int[] { 0, 1, 2, 3, 4 };
+            int[] partitionStartIndexes = new int[] { 0, 2 };
             ReadOnlyDataBlock roBlock = block.AsReadOnly();
-            ReadOnlyDataBlock chainProjection = roBlock.ProjectChain(partitionChains, partitionChainHeads[1]);
+            ReadOnlyDataBlock chainProjection = roBlock.ProjectChain(itemIndexes, partitionStartIndexes[1], 3);
             p.AddOrUpdate(chainProjection, new AddOrUpdateOptions());
 
             // Verify only the right items were added
@@ -337,12 +337,9 @@ namespace Arriba.Test.Model
             Assert.AreEqual(4, (int)t.Count);
         }
 
-        //[TestMethod]
+        [TestMethod]
         public void Table_AddAndUpdateInSameOperation()
         {
-            // BUG: ChooseSplit produces non-deterministic ordering how rows are processed
-            // in AddOrUpdate, this can cause two updates (Add+Update or Update+Update) to 
-            // occur in opposite order than intended by caller
             ITable_AddAndUpdateInSameOperation(() => new Table("Sample", 75000));
         }
 

--- a/Arriba/Arriba.Test/Model/TableTestsLarge.cs
+++ b/Arriba/Arriba.Test/Model/TableTestsLarge.cs
@@ -115,7 +115,7 @@ namespace Arriba.Test.Model
             items.SetColumn(4, seed.Select(i => i / 100).ToArray());
             items.SetColumn(5, seed.Select(i => i / 1000).ToArray());
 
-            table.AddOrUpdate(items, new AddOrUpdateOptions());
+            table.AddOrUpdate(items.AsReadOnly(), new AddOrUpdateOptions());
         }
 
         private static T FindColumnComponent<T>(IColumn column)

--- a/Arriba/Arriba/Model/ITable.cs
+++ b/Arriba/Arriba/Model/ITable.cs
@@ -59,7 +59,7 @@ namespace Arriba.Model
         ///  For each item, the value for each column is set to the provided values.
         /// </summary>
         /// <param name="values">Set of Columns and values to add or update</param>
-        void AddOrUpdate(DataBlock values, AddOrUpdateOptions options);
+        void AddOrUpdate(ReadOnlyDataBlock values, AddOrUpdateOptions options);
 
         /// <summary>
         ///  Delete items from this Table which meet the provided criteria.

--- a/Arriba/Arriba/Model/Partition.cs
+++ b/Arriba/Arriba/Model/Partition.cs
@@ -221,8 +221,6 @@ namespace Arriba.Model
         /// <param name="chainHead">starting index for the list of items that this partition should add</param>
         public void AddOrUpdate(ReadOnlyDataBlock values, AddOrUpdateOptions options)
         {
-            if (values == null) throw new ArgumentNullException("values");
-
             int columnCount = values.ColumnCount;
             int idColumnIndex = values.IndexOfColumn(this.IDColumn.Name);
 

--- a/Arriba/Tools/Arriba.Csv/Program.cs
+++ b/Arriba/Tools/Arriba.Csv/Program.cs
@@ -176,7 +176,7 @@ namespace Arriba.Csv
                     DataBlock toInsert = block;
                     if (columnNames != null) toInsert = toInsert.StripToColumns(columnNames);
 
-                    table.AddOrUpdate(toInsert, options);
+                    table.AddOrUpdate(toInsert.AsReadOnly(), options);
 
                     rowsImported += toInsert.RowCount;
                     Console.Write(".");


### PR DESCRIPTION
Created a ReadOnlyDataBlock which is a read-only wrapper of a datablock.
Create a further projection which can iterate along a specific chain of indexes.
Change ITable.AddOrUpdate to use the ReadOnlyDataBlock and eliminate the special API on Partition that only Table knows about.

This gets us 1 step further towards the layering of ITables inside of ITables being a repeatable pattern.  This also helps eliminate the possibility that AddOrUpdate could modify the provided data (which might wrap the users own arrays).