### PR TITLE
Arriba Build safety.

### DIFF
--- a/Arriba/Build.Website.cmd
+++ b/Arriba/Build.Website.cmd
@@ -3,7 +3,7 @@
 IF EXIST "%1" (
   ECHO - Synchronizing Configuration...
   ROBOCOPY /E /XO /NJH /NJS "%~dp0Arriba.Web\configuration" "%1"
-  ROBOCOPY /E /XO /NJH /NJS /MIR "%1" "%~dp0Arriba.Web\configuration"
+  ROBOCOPY /E /NJH /NJS /MIR "%1" "%~dp0Arriba.Web\configuration"
 ) ELSE (
   IF EXIST "%~dp0Arriba.Web\configuration" (
     IF EXIST "%~dp0Arriba.Web\configuration.BAK" RMDIR /S /Q "%~dp0Arriba.Web\configuration.BAK"

--- a/Arriba/Build.cmd
+++ b/Arriba/Build.cmd
@@ -1,7 +1,6 @@
 @ECHO OFF
 SETLOCAL ENABLEDELAYEDEXPANSION
-SET MsBuildPath=%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe
-IF NOT EXIST "%MsBuildPath%" SET MSBuildPath=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe
+SET MsBuildPath=%WINDIR%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe
 
 @REM unsigned build
 %~dp0..\.nuget\NuGet.exe restore %~dp0Arriba.All.sln 


### PR DESCRIPTION
  - Always use WinDir MSBuild (VS2015 or VS2017)
  - Always write all config files back to source location (no lost work)