### PR TITLE
Better organization for the RODB

### DIFF
--- a/Arriba/Arriba.Communication/Server/Application/ArribaImportApplication.cs
+++ b/Arriba/Arriba.Communication/Server/Application/ArribaImportApplication.cs
@@ -77,7 +77,7 @@ namespace Arriba.Server.Application
                     foreach (var blockBatch in reader.ReadAsDataBlockBatch(BatchSize))
                     {
                         response.RowCount += blockBatch.RowCount;
-                        table.AddOrUpdate(blockBatch.AsReadOnly());
+                        table.AddOrUpdate(blockBatch);
                     }
                 }
             }
@@ -98,7 +98,7 @@ namespace Arriba.Server.Application
             using (ctx.Monitor(MonitorEventLevel.Information, "Import.DataBlock", type: "Table", identity: tableName))
             {
                 DataBlock block = await ctx.Request.ReadBodyAsync<DataBlock>();
-                table.AddOrUpdate(block.AsReadOnly());
+                table.AddOrUpdate(block);
 
                 ImportResponse response = new ImportResponse();
                 response.TableName = tableName;
@@ -183,7 +183,7 @@ namespace Arriba.Server.Application
                         }
                     }
 
-                    table.AddOrUpdate(block.AsReadOnly());
+                    table.AddOrUpdate(block);
                 }
 
                 using (ctx.Monitor(MonitorEventLevel.Verbose, "table.save"))

--- a/Arriba/Arriba.Test/Model/AggregatorTests.cs
+++ b/Arriba/Arriba.Test/Model/AggregatorTests.cs
@@ -150,7 +150,7 @@ namespace Arriba.Test.Model
             // Add to a table with the desired column type, big enough to have multiple partitions
             Table table = new Table("Sample", 100000);
             table.AddColumn(new ColumnDetails("ID", columnType, null, "", true));
-            table.AddOrUpdate(block.AsReadOnly());
+            table.AddOrUpdate(block);
 
             // Build an AggregationQuery
             AggregationQuery q = new AggregationQuery();

--- a/Arriba/Arriba.Test/Model/Correctors/ExpressionCorrectorTests.cs
+++ b/Arriba/Arriba.Test/Model/Correctors/ExpressionCorrectorTests.cs
@@ -77,7 +77,7 @@ namespace Arriba.Test.Model.Correctors
                 }
             );
 
-            people.AddOrUpdate(block.AsReadOnly(), new AddOrUpdateOptions() { AddMissingColumns = true });
+            people.AddOrUpdate(block, new AddOrUpdateOptions() { AddMissingColumns = true });
 
             UserAliasCorrector corrector = new UserAliasCorrector(people);
 

--- a/Arriba/Arriba.Test/Model/DatabaseTests.cs
+++ b/Arriba/Arriba.Test/Model/DatabaseTests.cs
@@ -28,7 +28,7 @@ namespace Arriba.Test.Model
                     new string[] { "Michael Fanning", "Ryley Taketa", "Scott Louvau"},
                     new string[] { "T1", "T1", "T2" },
                     new string[] { "G1; G2", "G1; G3", "G4" }
-                }).AsReadOnly(), new AddOrUpdateOptions() { AddMissingColumns = true });
+                }), new AddOrUpdateOptions() { AddMissingColumns = true });
 
             Table orders = db.AddTable("Orders", 1000);
             orders.AddOrUpdate(new DataBlock(new string[] { "OrderNumber", "OrderedByAlias" }, 6,
@@ -36,7 +36,7 @@ namespace Arriba.Test.Model
                 {
                     new string[] { "O1", "O2", "O3", "O4", "O5", "O6" },
                     new string[] { "mikefan", "mikefan", "rtaket", "v-scolo", "rtaket", "mikefan; rtaket" }
-                }).AsReadOnly(), new AddOrUpdateOptions() { AddMissingColumns = true });
+                }), new AddOrUpdateOptions() { AddMissingColumns = true });
 
             SelectResult result;
 

--- a/Arriba/Arriba.Test/Model/SecureDatabaseTests.cs
+++ b/Arriba/Arriba.Test/Model/SecureDatabaseTests.cs
@@ -38,7 +38,7 @@ namespace Arriba.Test.Model
                     new string[] { "Bob", "Alice", "Alice", "Bob", "Bob" },
                     new byte[] { 3, 3, 2, 2, 0 }
                 });
-            t.AddOrUpdate(b.AsReadOnly());
+            t.AddOrUpdate(b);
 
             return db;
         }

--- a/Arriba/Arriba.Test/Model/TableTestsLarge.cs
+++ b/Arriba/Arriba.Test/Model/TableTestsLarge.cs
@@ -115,7 +115,7 @@ namespace Arriba.Test.Model
             items.SetColumn(4, seed.Select(i => i / 100).ToArray());
             items.SetColumn(5, seed.Select(i => i / 1000).ToArray());
 
-            table.AddOrUpdate(items.AsReadOnly(), new AddOrUpdateOptions());
+            table.AddOrUpdate(items, new AddOrUpdateOptions());
         }
 
         private static T FindColumnComponent<T>(IColumn column)

--- a/Arriba/Arriba/Model/AddOrUpdateOptions.cs
+++ b/Arriba/Arriba/Model/AddOrUpdateOptions.cs
@@ -19,6 +19,8 @@
     /// </summary>
     public class AddOrUpdateOptions
     {
+        public static AddOrUpdateOptions Default = new AddOrUpdateOptions();
+
         /// <summary>
         ///  Mode determines what to do with items with new IDs.
         ///  By default, rows are added for items with new IDs.

--- a/Arriba/Arriba/Model/ITable.cs
+++ b/Arriba/Arriba/Model/ITable.cs
@@ -59,7 +59,7 @@ namespace Arriba.Model
         ///  For each item, the value for each column is set to the provided values.
         /// </summary>
         /// <param name="values">Set of Columns and values to add or update</param>
-        void AddOrUpdate(ReadOnlyDataBlock values, AddOrUpdateOptions options);
+        void AddOrUpdate(DataBlock.ReadOnlyDataBlock values, AddOrUpdateOptions options);
 
         /// <summary>
         ///  Delete items from this Table which meet the provided criteria.

--- a/Arriba/Arriba/Model/Partition.cs
+++ b/Arriba/Arriba/Model/Partition.cs
@@ -11,6 +11,7 @@ using Arriba.Model.Expressions;
 using Arriba.Model.Query;
 using Arriba.Serialization;
 using Arriba.Structures;
+using System.Collections.Concurrent;
 
 namespace Arriba.Model
 {
@@ -219,7 +220,7 @@ namespace Arriba.Model
         /// <param name="partitionChains">storage for the set of linked lists indicating which values are in each partition.  The index is the row number in values
         /// of the corresponding item.  The value is the next item in the chain with -1 indicating the end.</param>
         /// <param name="chainHead">starting index for the list of items that this partition should add</param>
-        public void AddOrUpdate(ReadOnlyDataBlock values, AddOrUpdateOptions options)
+        public void AddOrUpdate(DataBlock.ReadOnlyDataBlock values, AddOrUpdateOptions options)
         {
             int columnCount = values.ColumnCount;
             int idColumnIndex = values.IndexOfColumn(this.IDColumn.Name);
@@ -247,18 +248,19 @@ namespace Arriba.Model
             }
         }
 
-        private ushort[] FindOrAssignLIDs(ReadOnlyDataBlock values, int idColumnIndex, AddOrUpdateMode mode)
+        private ushort[] FindOrAssignLIDs(DataBlock.ReadOnlyDataBlock values, int idColumnIndex, AddOrUpdateMode mode)
         {
             Type idColumnDataType = values.GetTypeForColumn(idColumnIndex);
 
             // If the insert array matches types with the column then we can use the native type to do a direct assignment from the input array
             // to the column array.  If the types do not match, we need to fallback to object to allow the Value class to handle the type conversion
-            ITypedAddOrUpdateWorker worker = NativeContainer.CreateTypedInstance<ITypedAddOrUpdateWorker>(typeof(AddOrUpdateWorker<>), idColumnDataType);
+            //ITypedAddOrUpdateWorker worker = NativeContainer.CreateTypedInstance<ITypedAddOrUpdateWorker>(typeof(AddOrUpdateWorker<>), idColumnDataType);
+            ITypedAddOrUpdateWorker worker = GetTypedWorker(idColumnDataType);
 
             return worker.FindOrAssignLIDs(this, values, idColumnIndex, mode);
         }
 
-        private void FillPartitionColumn(ReadOnlyDataBlock values, int columnIndex, ushort[] itemLIDs)
+        private void FillPartitionColumn(DataBlock.ReadOnlyDataBlock values, int columnIndex, ushort[] itemLIDs)
         {
             string columnName = values.Columns[columnIndex].Name;
             if (columnName.Equals(this.IDColumn.Name, StringComparison.OrdinalIgnoreCase)) return;
@@ -267,7 +269,8 @@ namespace Arriba.Model
 
             // If the insert array matches types with the column then we can use the native type to do a direct assignment from the input array
             // to the column array.  If the types do not match, we need to fallback to object to allow the Value class to handle the type conversion
-            ITypedAddOrUpdateWorker worker = NativeContainer.CreateTypedInstance<ITypedAddOrUpdateWorker>(typeof(AddOrUpdateWorker<>), dataBlockColumnDataType);
+            //ITypedAddOrUpdateWorker worker = NativeContainer.CreateTypedInstance<ITypedAddOrUpdateWorker>(typeof(AddOrUpdateWorker<>), dataBlockColumnDataType);
+            ITypedAddOrUpdateWorker worker = GetTypedWorker(dataBlockColumnDataType);
 
             worker.FillPartitionColumn(this, values, columnIndex, itemLIDs);
         }
@@ -275,8 +278,8 @@ namespace Arriba.Model
 
         private interface ITypedAddOrUpdateWorker
         {
-            ushort[] FindOrAssignLIDs(Partition p, ReadOnlyDataBlock values, int idColumnIndex, AddOrUpdateMode mode);
-            void FillPartitionColumn(Partition p, ReadOnlyDataBlock values, int columnIndex, ushort[] itemLIDs);
+            ushort[] FindOrAssignLIDs(Partition p, DataBlock.ReadOnlyDataBlock values, int idColumnIndex, AddOrUpdateMode mode);
+            void FillPartitionColumn(Partition p, DataBlock.ReadOnlyDataBlock values, int columnIndex, ushort[] itemLIDs);
         }
 
         /// <summary>
@@ -285,7 +288,7 @@ namespace Arriba.Model
         /// <typeparam name="T">Type of the column array</typeparam>
         private class AddOrUpdateWorker<T> : ITypedAddOrUpdateWorker
         {
-            public ushort[] FindOrAssignLIDs(Partition p, ReadOnlyDataBlock values, int idColumnIndex, AddOrUpdateMode mode)
+            public ushort[] FindOrAssignLIDs(Partition p, DataBlock.ReadOnlyDataBlock values, int idColumnIndex, AddOrUpdateMode mode)
             {
                 // TODO: consider keeping one instance of the worker long term? if so, this becomes a private class field
                 ValueTypeReference<T> vtr = new ValueTypeReference<T>();
@@ -302,11 +305,10 @@ namespace Arriba.Model
                     typedIdColumn = (IColumn<T>)idColumn.InnerColumn;
                 }
 
-                int index = 0;
-                foreach (T idValue in values.IterateColumn<T>(idColumnIndex))
+                for( int index = 0; index < values.RowCount; ++index)
                 {
                     // Look for the LIDs a
-                    T externalID = idValue;
+                    T externalID = values.GetValueT<T>(index, idColumnIndex);
                     if (typedIdColumn != null)
                     {
                         typedIdColumn.TryGetIndexOf(externalID, out itemLIDs[index]);
@@ -326,8 +328,6 @@ namespace Arriba.Model
                     {
                         throw new ArribaException(StringExtensions.Format("Item with ID '{0}', hash '{1:x}' incorrectly routed to Partition {2}.", externalID, idHash, p.Mask));
                     }
-
-                    index++;
                 }
 
                 // Go back and add the items which need to be added in a batch
@@ -335,9 +335,9 @@ namespace Arriba.Model
                 {
                     Dictionary<T, ushort> newlyAssignedLIDs = null;
 
-                    index = 0;
-                    foreach (T idValue in values.IterateColumn<T>(idColumnIndex))
+                    for (int index = 0; index < values.RowCount; ++index)
                     {
+                        T idValue = values.GetValueT<T>(index, idColumnIndex);
                         ushort lid = itemLIDs[index];
 
                         // If this is an add...
@@ -384,7 +384,6 @@ namespace Arriba.Model
                         }
 
                         itemLIDs[index] = lid;
-                        index++;
                     }
 
                     // Commit the updates to the values column if the column requires it (FastAddSortedColumn does)
@@ -394,7 +393,7 @@ namespace Arriba.Model
                 return itemLIDs;
             }
 
-            public void FillPartitionColumn(Partition p, ReadOnlyDataBlock values, int columnIndex, ushort[] itemLIDs)
+            public void FillPartitionColumn(Partition p, DataBlock.ReadOnlyDataBlock values, int columnIndex, ushort[] itemLIDs)
             {
                 string columnName = values.Columns[columnIndex].Name;
                 if (columnName.Equals(p.IDColumn.Name, StringComparison.OrdinalIgnoreCase)) return;
@@ -407,9 +406,9 @@ namespace Arriba.Model
                     typedColumn = (IColumn<T>)untypedColumn.InnerColumn;
                 }
 
-                int rowIndex = 0;
-                foreach (T value in values.IterateColumn<T>(columnIndex))
+                for( int rowIndex = 0; rowIndex < values.RowCount; ++rowIndex)
                 {
+                    T value = values.GetValueT<T>(rowIndex, columnIndex);
                     // If the item is new and no LID was assigned, we don't set values
                     if (itemLIDs[rowIndex] == ushort.MaxValue) continue;
                     try
@@ -428,7 +427,6 @@ namespace Arriba.Model
                         throw new ArribaWriteException(values[rowIndex, 0], columnName, value, ex);
                     }
 
-                    rowIndex++;
                 }
             }
         }
@@ -582,6 +580,24 @@ namespace Arriba.Model
             {
                 this.DetailsByColumn[columnName].WriteBinary(context);
                 this.Columns[columnName].WriteBinary(context);
+            }
+        }
+        #endregion
+
+        #region Type Worker Cache
+        private static Dictionary<Type, ITypedAddOrUpdateWorker> _workerCache = new Dictionary<Type, ITypedAddOrUpdateWorker>();
+        private static ITypedAddOrUpdateWorker GetTypedWorker(Type type)
+        {
+            lock (_workerCache)
+            {
+                ITypedAddOrUpdateWorker instance;
+                if (_workerCache.TryGetValue(type, out instance) == false)
+                {
+                    instance = NativeContainer.CreateTypedInstance<ITypedAddOrUpdateWorker>(typeof(AddOrUpdateWorker<>), type);
+                    _workerCache.Add(type, instance);
+                }
+
+                return instance;
             }
         }
         #endregion

--- a/Arriba/Arriba/Model/Table.cs
+++ b/Arriba/Arriba/Model/Table.cs
@@ -121,7 +121,7 @@ namespace Arriba.Model
 
         protected IReadOnlyList<Partition> GetPartitions()
         {
-            return _partitions;
+            return _partitions.AsReadOnly();
         }
 
         #region Column Operations

--- a/Arriba/Tools/Arriba.Csv/Program.cs
+++ b/Arriba/Tools/Arriba.Csv/Program.cs
@@ -176,7 +176,7 @@ namespace Arriba.Csv
                     DataBlock toInsert = block;
                     if (columnNames != null) toInsert = toInsert.StripToColumns(columnNames);
 
-                    table.AddOrUpdate(toInsert.AsReadOnly(), options);
+                    table.AddOrUpdate(toInsert, options);
 
                     rowsImported += toInsert.RowCount;
                     Console.Write(".");


### PR DESCRIPTION
IterateItems caused allocations but by changing the nesting, the RODB can directly access the arrays inside a DB.  Also added an implicit cast operator so that calling code doesn't have to change.