### PR TITLE
Xsv Sanitize perf

### DIFF
--- a/Elfie/Elfie/Model/Strings/String8.cs
+++ b/Elfie/Elfie/Model/Strings/String8.cs
@@ -228,14 +228,14 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
         /// <returns>String8 with the value of this string starting at index</returns>
         public String8 Substring(int index)
         {
-            // Length Default: Return rest of string
-            int length = _length - index;
+            // Verify index non-negative
+            if (index < 0 || index > _length) throw new ArgumentOutOfRangeException("index");
 
-            // Verify in bounds
-            if (length < 0) throw new ArgumentOutOfRangeException("length");
+            // If index is zero, return the same instance
+            if (index == 0) return this;
 
             // Build a substring tied to the same buffer
-            return new String8(_buffer, _index + index, length);
+            return new String8(_buffer, _index + index, _length - index);
         }
 
         /// <summary>
@@ -248,7 +248,8 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
         public String8 Substring(int index, int length)
         {
             // Verify in bounds
-            if (index + length > _length) throw new ArgumentOutOfRangeException("length");
+            if (index < 0) throw new ArgumentOutOfRangeException("index");
+            if (length < 0 || index + length > _length) throw new ArgumentOutOfRangeException("length");
 
             // Build a substring tied to the same buffer
             return new String8(_buffer, _index + index, length);
@@ -337,22 +338,22 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
             result = false;
             if (IsEmpty()) return false;
 
-            if(this.CompareTo("true", true) == 0)
+            if (this.CompareTo("true", true) == 0)
             {
                 result = true;
                 return true;
             }
-            else if(this.CompareTo("false", true) == 0)
+            else if (this.CompareTo("false", true) == 0)
             {
                 result = false;
                 return true;
             }
-            else if(this.CompareTo("1", false) == 0)
+            else if (this.CompareTo("1", false) == 0)
             {
                 result = true;
                 return true;
             }
-            else if(this.CompareTo("0", false) == 0)
+            else if (this.CompareTo("0", false) == 0)
             {
                 result = false;
                 return true;
@@ -447,7 +448,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
             if (buffer.Length + index < requiredLength) throw new ArgumentException("String8.FromInteger requires an 11 byte buffer for integer conversion.");
 
             // Write minus sign if negative
-            if(isNegative) buffer[index++] = (byte)'-';
+            if (isNegative) buffer[index++] = (byte)'-';
 
             // Write digits right to left
             for (int j = index + digits - 1; j >= index; --j)
@@ -482,7 +483,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
             FromInteger(value.Day, buffer, index + 8, 2);
 
             // Thh:mm:ssZ
-            if(value.TimeOfDay > TimeSpan.Zero)
+            if (value.TimeOfDay > TimeSpan.Zero)
             {
                 length = 20;
 
@@ -554,8 +555,8 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
 
             // Construct DateTime to avoid failures due to days being out of range (leap year and month length)
             result = new DateTime(year, month, 1, hour, minute, second, DateTimeKind.Utc);
-            if(day > 1) result = result.AddDays(day - 1);
-            
+            if (day > 1) result = result.AddDays(day - 1);
+
             // Return false for invalid leap days
             if (result.Month != month) return false;
 

--- a/Elfie/Xsv/Sanitize/Hashing.cs
+++ b/Elfie/Xsv/Sanitize/Hashing.cs
@@ -5,6 +5,7 @@ namespace Xsv.Sanitize
 {
     public static class Hashing
     {
+        private static HashAlgorithm hasher;
         private static byte[] buffer;
 
         /// <summary>
@@ -31,6 +32,7 @@ namespace Xsv.Sanitize
         /// <returns>uint of hash result</returns>
         public static uint Hash(String8 value, uint hashKeyHash)
         {
+            if (hasher == null) hasher = SHA256Managed.Create();
             if (buffer == null || buffer.Length < value.Length + 4) buffer = new byte[value.Length + 4];
 
             buffer[0] = (byte)(hashKeyHash & 0xFF);
@@ -39,9 +41,7 @@ namespace Xsv.Sanitize
             buffer[3] = (byte)((hashKeyHash >> 24) & 0xFF);
             value.WriteTo(buffer, 4);
 
-            HashAlgorithm hasher = SHA256Managed.Create();
             byte[] hash = hasher.ComputeHash(buffer, 0, value.Length + 4);
-
             uint result = (uint)((hash[0] << 24) + (hash[1] << 16) + (hash[2] << 8) + hash[3]);
             return result;
         }


### PR DESCRIPTION
  - Hashing: Cache SHA256 instance.
  - Note: All other crypto hashes were slower.
  - String8: Safer bounds checking, return same instance for Substring(0).