### PR TITLE
AllCounts echos query

### DIFF
--- a/Arriba/Arriba.Test/Extensions/IExpressionExtensionsTests.cs
+++ b/Arriba/Arriba.Test/Extensions/IExpressionExtensionsTests.cs
@@ -19,10 +19,10 @@ namespace Arriba.Test.Extensions
         {
             IExpression sample = QueryParser.Parse("everything && Title:hello && ID < 394000 && (Title:\"Quoted Value\" || !(Status = \"Active\"))");
 
-            Assert.AreEqual("*:everything|Title:hello|ID < 394000|Title:\"Quoted Value\"|Status = Active", String.Join("|", sample.GetAllTerms(null)));
-            Assert.AreEqual("*:everything|Title:hello|Title:\"Quoted Value\"", String.Join("|", sample.GetAllTerms("Title")));
-            Assert.AreEqual("*:everything|Status = Active", String.Join("|", sample.GetAllTerms("status")));
-            Assert.AreEqual("*:everything", String.Join("|", sample.GetAllTerms("Missing")));
+            Assert.AreEqual("[*]:everything|[Title]:hello|[ID] < 394000|[Title]:\"Quoted Value\"|[Status] = Active", String.Join("|", sample.GetAllTerms(null)));
+            Assert.AreEqual("[*]:everything|[Title]:hello|[Title]:\"Quoted Value\"", String.Join("|", sample.GetAllTerms("Title")));
+            Assert.AreEqual("[*]:everything|[Status] = Active", String.Join("|", sample.GetAllTerms("status")));
+            Assert.AreEqual("[*]:everything", String.Join("|", sample.GetAllTerms("Missing")));
         }
     }
 }

--- a/Arriba/Arriba.Test/Model/Query/QueryParserTests.cs
+++ b/Arriba/Arriba.Test/Model/Query/QueryParserTests.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Arriba.Model.Expressions;
 using Arriba.Model.Query;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Text;
 
 namespace Arriba.Test.Model.Query
 {
@@ -17,20 +20,20 @@ namespace Arriba.Test.Model.Query
             Assert.AreEqual("", QueryParser.Parse("").ToString());
 
             // Single Bare Term (implied * : value)
-            Assert.AreEqual("*:editor", QueryParser.Parse("editor").ToString());
+            Assert.AreEqual("[*]:editor", QueryParser.Parse("editor").ToString());
 
             // Single Bare Quoted Value, unterminated
-            Assert.AreEqual("*:\"Scott Louv\"", QueryParser.Parse("\"Scott Louv").ToString());
+            Assert.AreEqual("[*]:\"Scott Louv\"", QueryParser.Parse("\"Scott Louv").ToString());
 
             // Bare Terms (implied AND)
-            Assert.AreEqual("(*:editor AND *:ide)", QueryParser.Parse("editor ide").ToString());
+            Assert.AreEqual("[*]:editor AND [*]:ide", QueryParser.Parse("editor ide").ToString());
 
             // Column = Value
-            Assert.AreEqual("CreatedBy = Scott", QueryParser.Parse("CreatedBy=Scott").ToString());
+            Assert.AreEqual("[CreatedBy] = Scott", QueryParser.Parse("CreatedBy=Scott").ToString());
 
             // Column = Empty
-            Assert.AreEqual("CreatedBy = \"\"", QueryParser.Parse("CreatedBy=\"\"").ToString());
-            Assert.AreEqual("CreatedBy <> \"\"", QueryParser.Parse("CreatedBy<>\"\"").ToString());
+            Assert.AreEqual("[CreatedBy] = \"\"", QueryParser.Parse("CreatedBy=\"\"").ToString());
+            Assert.AreEqual("[CreatedBy] <> \"\"", QueryParser.Parse("CreatedBy<>\"\"").ToString());
 
             // Braced Column = Quoted Value
             Assert.AreEqual("[Created By] < \"Scott Louvau\"", QueryParser.Parse("[Created By]<\"Scott Louvau\"").ToString());
@@ -42,24 +45,24 @@ namespace Arriba.Test.Model.Query
             Assert.AreEqual("[Created  ] <> \"\"", QueryParser.Parse("[Created  ", true).ToString());
 
             // Negated Bare Value
-            Assert.AreEqual("NOT(*:editor)", QueryParser.Parse("-editor").ToString());
+            Assert.AreEqual("NOT([*]:editor)", QueryParser.Parse("-editor").ToString());
 
             // Multiple Clauses
-            Assert.AreEqual("([Created By] = \"Scott Louvau\" AND Priority <= 3 AND *:verified)", QueryParser.Parse("[Created By]=\"Scott Louvau\" && Priority <= 3 && verified").ToString());
+            Assert.AreEqual("[Created By] = \"Scott Louvau\" AND [Priority] <= 3 AND [*]:verified", QueryParser.Parse("[Created By]=\"Scott Louvau\" && Priority <= 3 && verified").ToString());
 
             // Nested Subqueries
-            Assert.AreEqual("(Priority <= 3 AND (*:verified OR *:checked OR *:scanned OR Triage = \"\"))", QueryParser.Parse("Priority <= 3 && (verified || checked || scanned || Triage=\"\")").ToString());
+            Assert.AreEqual("[Priority] <= 3 AND ([*]:verified OR [*]:checked OR [*]:scanned OR [Triage] = \"\")", QueryParser.Parse("Priority <= 3 && (verified || checked || scanned || Triage=\"\")").ToString());
 
             // Unclosed subquery
-            Assert.AreEqual("(Priority <= 3 AND (*:verified OR *:chec))", QueryParser.Parse("Priority <= 3 && (verified || chec").ToString());
+            Assert.AreEqual("[Priority] <= 3 AND ([*]:verified OR [*]:chec)", QueryParser.Parse("Priority <= 3 && (verified || chec").ToString());
 
             // Trailing operator - with hint, hint term
-            Assert.AreEqual("(Priority <= 3 AND *:\"\")", QueryParser.Parse("Priority <= 3 &&", true).ToString());
-            Assert.AreEqual("(Priority <= 3 OR *:\"\")", QueryParser.Parse("Priority <= 3 ||", true).ToString());
+            Assert.AreEqual("[Priority] <= 3 AND [*]:\"\"", QueryParser.Parse("Priority <= 3 &&", true).ToString());
+            Assert.AreEqual("[Priority] <= 3 OR [*]:\"\"", QueryParser.Parse("Priority <= 3 ||", true).ToString());
 
             // Trailing operator - no hint, no next clause
-            Assert.AreEqual("Priority <= 3", QueryParser.Parse("Priority <= 3 &&").ToString());
-            Assert.AreEqual("Priority <= 3", QueryParser.Parse("Priority <= 3 ||").ToString());
+            Assert.AreEqual("[Priority] <= 3", QueryParser.Parse("Priority <= 3 &&").ToString());
+            Assert.AreEqual("[Priority] <= 3", QueryParser.Parse("Priority <= 3 ||").ToString());
 
             // Non-identifier junk
             Assert.AreEqual("", QueryParser.Parse("<<<<>>>>").ToString());
@@ -68,51 +71,86 @@ namespace Arriba.Test.Model.Query
         [TestMethod]
         public void QueryParser_AllTokenForms()
         {
-            Assert.AreEqual("(*:a AND *:b AND *:c AND *:d)", QueryParser.Parse("a && b & c AND d").ToString());
-            Assert.AreEqual("(*:a OR *:b OR *:c OR *:d)", QueryParser.Parse("a || b | c OR d").ToString());
-            Assert.AreEqual("(NOT(*:a) AND NOT(*:b) AND NOT(*:c))", QueryParser.Parse("!a -b NOT c").ToString());
-            Assert.AreEqual("(t = a AND t = b)", QueryParser.Parse("t=a t==b").ToString());
-            Assert.AreEqual("(t <> a AND t <> b)", QueryParser.Parse("t!=a t<>b").ToString());
-            Assert.AreEqual("(t:a AND t:b AND t:c AND t:d AND t:e)", QueryParser.Parse("t:a AND t MATCH b AND t LIKE c AND t FREETEXT d AND t CONTAINS e").ToString());
-            Assert.AreEqual("(t::a AND t::b)", QueryParser.Parse("t::a AND t MATCHEXACT b").ToString());
-            Assert.AreEqual("(a STARTSWITH t AND b STARTSWITH t AND c STARTSWITH t)", QueryParser.Parse("a |> t && b STARTSWITH t && c UNDER t").ToString());
+            Assert.AreEqual("[*]:a AND [*]:b AND [*]:c AND [*]:d", QueryParser.Parse("a && b & c AND d").ToString());
+            Assert.AreEqual("[*]:a OR [*]:b OR [*]:c OR [*]:d", QueryParser.Parse("a || b | c OR d").ToString());
+            Assert.AreEqual("NOT([*]:a) AND NOT([*]:b) AND NOT([*]:c)", QueryParser.Parse("!a -b NOT c").ToString());
+            Assert.AreEqual("[t] = a AND [t] = b", QueryParser.Parse("t=a t==b").ToString());
+            Assert.AreEqual("[t] <> a AND [t] <> b", QueryParser.Parse("t!=a t<>b").ToString());
+            Assert.AreEqual("[t]:a AND [t]:b AND [t]:c AND [t]:d AND [t]:e", QueryParser.Parse("t:a AND t MATCH b AND t LIKE c AND t FREETEXT d AND t CONTAINS e").ToString());
+            Assert.AreEqual("[t]::a AND [t]::b", QueryParser.Parse("t::a AND t MATCHEXACT b").ToString());
+            Assert.AreEqual("[a] STARTSWITH t AND [b] STARTSWITH t AND [c] STARTSWITH t", QueryParser.Parse("a |> t && b STARTSWITH t && c UNDER t").ToString());
         }
 
         [TestMethod]
         public void QueryParser_ExpressionPrecedence()
         {
             // AND is higher precedence than OR
-            Assert.AreEqual("((*:A AND *:B) OR *:C)", QueryParser.Parse("A AND B OR C").ToString());
-            Assert.AreEqual("(*:A OR (*:B AND *:C))", QueryParser.Parse("A OR B AND C").ToString());
+            Assert.AreEqual("(([*]:A AND [*]:B) OR [*]:C)", ToParenthesizedString(QueryParser.Parse("A AND B OR C")));
+            Assert.AreEqual("([*]:A OR ([*]:B AND [*]:C))", ToParenthesizedString(QueryParser.Parse("A OR B AND C")));
 
             // NOT is higher precedence than AND or OR
-            Assert.AreEqual("(*:A OR (NOT(*:B) AND *:C))", QueryParser.Parse("A OR NOT B AND C").ToString());
-            Assert.AreEqual("((*:A AND NOT(*:B)) OR *:C)", QueryParser.Parse("A AND NOT B OR C").ToString());
+            Assert.AreEqual("([*]:A OR (NOT([*]:B) AND [*]:C))", ToParenthesizedString(QueryParser.Parse("A OR NOT B AND C")));
+            Assert.AreEqual("(([*]:A AND NOT([*]:B)) OR [*]:C)", ToParenthesizedString(QueryParser.Parse("A AND NOT B OR C")));
 
             // AND precedence works with bare terms
-            Assert.AreEqual("((*:A AND *:B) OR *:C)", QueryParser.Parse("A B OR C").ToString());
-            Assert.AreEqual("(*:A OR (*:B AND *:C))", QueryParser.Parse("A OR B C").ToString());
+            Assert.AreEqual("(([*]:A AND [*]:B) OR [*]:C)", ToParenthesizedString(QueryParser.Parse("A B OR C")));
+            Assert.AreEqual("([*]:A OR ([*]:B AND [*]:C))", ToParenthesizedString(QueryParser.Parse("A OR B C")));
 
             // Explicit Parenthesis correctly override default precedence
-            Assert.AreEqual("(*:A AND (*:B OR *:C))", QueryParser.Parse("A AND (B OR C)").ToString());
-            Assert.AreEqual("((*:A OR *:B) AND *:C)", QueryParser.Parse("(A OR B) AND C").ToString());
-            Assert.AreEqual("(*:A OR NOT((*:B OR *:C)))", QueryParser.Parse("A OR NOT(B OR C)").ToString());
+            Assert.AreEqual("([*]:A AND ([*]:B OR [*]:C))", ToParenthesizedString(QueryParser.Parse("A AND (B OR C)")));
+            Assert.AreEqual("(([*]:A OR [*]:B) AND [*]:C)", ToParenthesizedString(QueryParser.Parse("(A OR B) AND C")));
+        }
+
+        /// <summary>
+        ///  Return the query as a string with all parenthesis to clarify
+        ///  precedence.
+        /// </summary>
+        /// <param name="query">IExpression to convert</param>
+        /// <returns>Text query with all terms parenthesized</returns>
+        public static string ToParenthesizedString(IExpression query)
+        {
+            StringBuilder result = new StringBuilder();
+            ToParenthesizedString(query, result);
+            return result.ToString();
+        }
+
+        private static void ToParenthesizedString(IExpression query, StringBuilder result)
+        {
+            if ((query is AndExpression) || (query is OrExpression))
+            {
+                result.Append("(");
+
+                string joinWith = (query is AndExpression ? " AND " : " OR ");
+                IList<IExpression> children = query.Children();
+                for (int i = 0; i < children.Count; ++i)
+                {
+                    IExpression child = children[i];
+                    if (i > 0) result.Append(joinWith);
+                    ToParenthesizedString(child, result);
+                }
+
+                result.Append(")");
+            }
+            else
+            {
+                result.Append(query);
+            }
         }
 
         [TestMethod]
         public void QueryParser_EscapedValues()
         {
             // Escaped quotes are whole value (no spacing, start and end)
-            Assert.AreEqual("Value = \"\"\"\"\"\"", QueryParser.Parse("Value = \"\"\"\"\"\"").ToString());
+            Assert.AreEqual("[Value] = \"\"\"\"\"\"", QueryParser.Parse("Value = \"\"\"\"\"\"").ToString());
 
             // Escaped Quotes in Value with spacing
-            Assert.AreEqual("Value = \"Don't \"\"forget\"\"\"", QueryParser.Parse("Value = \"Don't \"\"forget\"\"\"").ToString());
+            Assert.AreEqual("[Value] = \"Don't \"\"forget\"\"\"", QueryParser.Parse("Value = \"Don't \"\"forget\"\"\"").ToString());
 
             // Spacing between quotes in value - not an escaped quote
-            Assert.AreEqual("(Value = \"Don't \" AND *:\"forget\"\"\")", QueryParser.Parse("Value = \"Don't \" \"forget\"\"\"").ToString());
+            Assert.AreEqual("[Value] = \"Don't \" AND [*]:\"forget\"\"\"", QueryParser.Parse("Value = \"Don't \" \"forget\"\"\"").ToString());
 
             // Braces in quotes not interpreted oddly
-            Assert.AreEqual("Value = []", QueryParser.Parse("Value = \"[]\"").ToString());
+            Assert.AreEqual("[Value] = []", QueryParser.Parse("Value = \"[]\"").ToString());
 
             // Braces escaped are whole value
             Assert.AreEqual("[]]]]] = something", QueryParser.Parse("[]]]]] = something").ToString());
@@ -124,13 +162,13 @@ namespace Arriba.Test.Model.Query
             Assert.AreEqual("", QueryParser.Parse("\"Title\"=Something").ToString());
 
             // Braced Value worked; braces don't interrupt value
-            Assert.AreEqual("Title = [Something]", QueryParser.Parse("Title=[Something]").ToString());
+            Assert.AreEqual("[Title] = [Something]", QueryParser.Parse("Title=[Something]").ToString());
         }
 
         [TestMethod]
         public void QueryParser_CaseSensitivity()
         {
-            Assert.AreEqual("(*:louvau AND (Priority = 3 OR Priority = 2))", QueryParser.Parse("louvau and (Priority = 3 Or Priority = 2)").ToString());
+            Assert.AreEqual("[*]:louvau AND ([Priority] = 3 OR [Priority] = 2)", QueryParser.Parse("louvau and (Priority = 3 Or Priority = 2)").ToString());
         }
 
         [TestMethod]
@@ -157,59 +195,59 @@ namespace Arriba.Test.Model.Query
             Assert.AreEqual("", QueryParser.Parse("Title > ").ToString());
 
             // Incomplete quoted value - search value so far
-            Assert.AreEqual("*:Starting", QueryParser.Parse("\"Starting").ToString());
+            Assert.AreEqual("[*]:Starting", QueryParser.Parse("\"Starting").ToString());
 
             // Incomplete parenthesized group - search terms so far
-            Assert.AreEqual("(*:Starting OR *:Ending)", QueryParser.Parse("(Starting || Ending").ToString());
+            Assert.AreEqual("[*]:Starting OR [*]:Ending", QueryParser.Parse("(Starting || Ending").ToString());
 
             // Incomplete negate operator (it's a bare value until the operator is complete)
-            Assert.AreEqual("*:Priority", QueryParser.Parse("Priority !").ToString());
+            Assert.AreEqual("[*]:Priority", QueryParser.Parse("Priority !").ToString());
         }
 
         [TestMethod]
         public void QueryParser_ValuesWithSpecialCharacters()
         {
             // Verify casing preserved in values with "AND", "OR", "NOT" in them
-            Assert.AreEqual("([Area Path] = Product\\Feature AND Resolution = \"Not Repro\" AND Title:or)", QueryParser.Parse("[Area Path] = \"Product\\Feature\" AND Resolution = \"Not Repro\" AND Title:or").ToString());
+            Assert.AreEqual("[Area Path] = Product\\Feature AND [Resolution] = \"Not Repro\" AND [Title]:or", QueryParser.Parse("[Area Path] = \"Product\\Feature\" AND Resolution = \"Not Repro\" AND Title:or").ToString());
 
             // Negation Operators: Allowed in column names and values
-            Assert.AreEqual("background-color:dark-blue", QueryParser.Parse("background-color:dark-blue").ToString());
-            Assert.AreEqual("background!color:dark!blue", QueryParser.Parse("background!color:dark!blue").ToString());
+            Assert.AreEqual("[background-color]:dark-blue", QueryParser.Parse("background-color:dark-blue").ToString());
+            Assert.AreEqual("[background!color]:dark!blue", QueryParser.Parse("background!color:dark!blue").ToString());
 
             // Dots: Allowed in column names and values
-            Assert.AreEqual("background.color:dark.blue", QueryParser.Parse("background.color:dark.blue").ToString());
+            Assert.AreEqual("[background.color]:dark.blue", QueryParser.Parse("background.color:dark.blue").ToString());
 
             // Parens: Not allowed in values
-            Assert.AreEqual("(background-image:url AND *:something)", QueryParser.Parse("background-image:url(something)").ToString());
+            Assert.AreEqual("[background-image]:url AND [*]:something", QueryParser.Parse("background-image:url(something)").ToString());
 
             // Parens: Not allowed in column names (causes parse error here, column name interpreted as two values)
             Assert.AreEqual("", QueryParser.Parse("background(image):url(something)").ToString());
 
             // Boolean Operators: Allowed in column names or values
-            Assert.AreEqual("one&two|three&&four||five:one&two|three&&four||five", QueryParser.Parse("one&two|three&&four||five:one&two|three&&four||five").ToString());
+            Assert.AreEqual("[one&two|three&&four||five]:one&two|three&&four||five", QueryParser.Parse("one&two|three&&four||five:one&two|three&&four||five").ToString());
 
             // Compare Operators interrupt column names
-            Assert.AreEqual("a::b", QueryParser.Parse("a::b").ToString());
-            Assert.AreEqual("a <= b", QueryParser.Parse("a<=b").ToString());
-            Assert.AreEqual("a >= b", QueryParser.Parse("a>=b").ToString());
-            Assert.AreEqual("a = b", QueryParser.Parse("a==b").ToString());
-            Assert.AreEqual("a <> b", QueryParser.Parse("a!=b").ToString());
-            Assert.AreEqual("a <> b", QueryParser.Parse("a<>b").ToString());
-            Assert.AreEqual("a:b", QueryParser.Parse("a:b").ToString());
-            Assert.AreEqual("a < b", QueryParser.Parse("a<b").ToString());
-            Assert.AreEqual("a > b", QueryParser.Parse("a>b").ToString());
-            Assert.AreEqual("a = b", QueryParser.Parse("a=b").ToString());
+            Assert.AreEqual("[a]::b", QueryParser.Parse("a::b").ToString());
+            Assert.AreEqual("[a] <= b", QueryParser.Parse("a<=b").ToString());
+            Assert.AreEqual("[a] >= b", QueryParser.Parse("a>=b").ToString());
+            Assert.AreEqual("[a] = b", QueryParser.Parse("a==b").ToString());
+            Assert.AreEqual("[a] <> b", QueryParser.Parse("a!=b").ToString());
+            Assert.AreEqual("[a] <> b", QueryParser.Parse("a<>b").ToString());
+            Assert.AreEqual("[a]:b", QueryParser.Parse("a:b").ToString());
+            Assert.AreEqual("[a] < b", QueryParser.Parse("a<b").ToString());
+            Assert.AreEqual("[a] > b", QueryParser.Parse("a>b").ToString());
+            Assert.AreEqual("[a] = b", QueryParser.Parse("a=b").ToString());
 
             // Compare operators don't interrupt values
-            Assert.AreEqual("a::b:<=>==<>c", QueryParser.Parse("a::b:<=>==<>c").ToString());
+            Assert.AreEqual("[a]::b:<=>==<>c", QueryParser.Parse("a::b:<=>==<>c").ToString());
         }
 
         [TestMethod]
         public void ValuesContainingKeywords()
         {
             // Try terms which start with, contain, or end with keywords (NOT, AND, OR)
-            Assert.AreEqual("(*:noted AND *:corn AND *:sandwiches)", QueryParser.Parse("noted corn sandwiches").ToString());
-            Assert.AreEqual("(*:org AND *:constructor)", QueryParser.Parse("org constructor").ToString());
+            Assert.AreEqual("[*]:noted AND [*]:corn AND [*]:sandwiches", QueryParser.Parse("noted corn sandwiches").ToString());
+            Assert.AreEqual("[*]:org AND [*]:constructor", QueryParser.Parse("org constructor").ToString());
         }
     }
 }

--- a/Arriba/Arriba.Test/Model/SecureDatabaseTests.cs
+++ b/Arriba/Arriba.Test/Model/SecureDatabaseTests.cs
@@ -65,7 +65,7 @@ namespace Arriba.Test.Model
 
             // Run the Query without security. Expect no restrictions and no security checks.
             result = db.Query(new SelectQuery(q), (si) => { Assert.Fail("No security checks for unsecured table"); return true; });
-            Assert.AreEqual("*:One", result.Query.Where.ToString());
+            Assert.AreEqual("[*]:One", result.Query.Where.ToString());
             Assert.IsFalse(HasRestrictedClauses(result.Query.Where));
             Assert.AreEqual("ID, Priority, SecretOwner, SecretPriority, Title", String.Join(", ", ((SelectQuery)result.Query).Columns));
 
@@ -75,13 +75,13 @@ namespace Arriba.Test.Model
             // Run the Query as a user in all column restriction groups
             // Verify the query is unrestricted - no WHERE clause and no filtered columns
             result = db.Query(new SelectQuery(q), (si) => si.Name == "g1" || si.Name == "g2");
-            Assert.AreEqual("*:One", result.Query.Where.ToString());
+            Assert.AreEqual("[*]:One", result.Query.Where.ToString());
             Assert.IsFalse(HasRestrictedClauses(result.Query.Where));
             Assert.AreEqual("ID, Priority, SecretOwner, SecretPriority, Title", String.Join(", ", ((SelectQuery)result.Query).Columns));
 
             // Run the query as a user in G1 only; verify G2 restricted columns excluded
             result = db.Query(new SelectQuery(q), (si) => si.Name == "g1");
-            Assert.AreEqual("*:One", result.Query.Where.ToString());
+            Assert.AreEqual("[*]:One", result.Query.Where.ToString());
             Assert.IsTrue(HasRestrictedClauses(result.Query.Where));
             Assert.AreEqual("ID, Priority, SecretOwner, Title", String.Join(", ", ((SelectQuery)result.Query).Columns));
 
@@ -89,7 +89,7 @@ namespace Arriba.Test.Model
             // Verify WHERE clause restriction, but no column restrictions
             // Security design is EITHER row or column security.
             result = db.Query(new SelectQuery(q), (si) => si.Name == "g3");
-            Assert.AreEqual("(SecretPriority > 1 AND *:One)", result.Query.Where.ToString());
+            Assert.AreEqual("[SecretPriority] > 1 AND [*]:One", result.Query.Where.ToString());
             Assert.IsFalse(HasRestrictedClauses(result.Query.Where));
             Assert.AreEqual("ID, Priority, SecretOwner, SecretPriority, Title", String.Join(", ", ((SelectQuery)result.Query).Columns));
 
@@ -97,21 +97,21 @@ namespace Arriba.Test.Model
             // Verify WHERE clause restriction, but no column restrictions
             // Security design is EITHER row or column security.
             result = db.Query(new SelectQuery(q), (si) => si.Name == "g4");
-            Assert.AreEqual("(SecretPriority > 2 AND *:One)", result.Query.Where.ToString());
+            Assert.AreEqual("[SecretPriority] > 2 AND [*]:One", result.Query.Where.ToString());
             Assert.IsFalse(HasRestrictedClauses(result.Query.Where));
             Assert.AreEqual("ID, Priority, SecretOwner, SecretPriority, Title", String.Join(", ", ((SelectQuery)result.Query).Columns));
 
             // Run the Query as a user in all groups
             // Verify WHERE clause restriction for *first* matching group, no column restrictions
             result = db.Query(new SelectQuery(q), (si) => true);
-            Assert.AreEqual("(SecretPriority > 1 AND *:One)", result.Query.Where.ToString());
+            Assert.AreEqual("[SecretPriority] > 1 AND [*]:One", result.Query.Where.ToString());
             Assert.IsFalse(HasRestrictedClauses(result.Query.Where));
             Assert.AreEqual("ID, Priority, SecretOwner, SecretPriority, Title", String.Join(", ", ((SelectQuery)result.Query).Columns));
 
             // Run the Query as a user in no groups.
             // Verify all column restrictions, no where clause filter
             result = db.Query(new SelectQuery(q), (si) => false);
-            Assert.AreEqual("*:One", result.Query.Where.ToString());
+            Assert.AreEqual("[*]:One", result.Query.Where.ToString());
             Assert.IsTrue(HasRestrictedClauses(result.Query.Where));
             Assert.AreEqual("ID, Priority, Title", String.Join(", ", ((SelectQuery)result.Query).Columns));
 
@@ -123,12 +123,12 @@ namespace Arriba.Test.Model
 
             // Add a query clause for a restricted column when in the required group. Verify success.
             result = db.Query(new SelectQuery(q) { Where = QueryParser.Parse("One AND SecretOwner=Bob") }, (si) => si.Name == "g1");
-            Assert.AreEqual("(*:One AND SecretOwner = Bob)", result.Query.Where.ToString());
+            Assert.AreEqual("[*]:One AND [SecretOwner] = Bob", result.Query.Where.ToString());
             Assert.IsTrue(HasRestrictedClauses(result.Query.Where));
 
             // Ask for restricted columns in result listing. Verify restricted columns allowed only for my group, warning for removed column.
             result = db.Query(new SelectQuery(q) { Columns = new string[] { "Title", "SecretOwner", "SecretPriority" } }, (si) => si.Name == "g1");
-            Assert.AreEqual("*:One", result.Query.Where.ToString());
+            Assert.AreEqual("[*]:One", result.Query.Where.ToString());
             Assert.IsTrue(HasRestrictedClauses(result.Query.Where));
             Assert.AreEqual("Title, SecretOwner", String.Join(", ", ((SelectQuery)result.Query).Columns));
             Assert.AreEqual("SecretPriority", String.Join(", ", result.Details.AccessDeniedColumns));
@@ -163,7 +163,7 @@ namespace Arriba.Test.Model
 
             // Run the Query without security. Expect no restrictions and no security checks.
             result = db.Query(new AggregationQuery(q), (si) => { Assert.Fail("No security checks for unsecured table"); return true; });
-            Assert.AreEqual("*:One", result.Query.Where.ToString());
+            Assert.AreEqual("[*]:One", result.Query.Where.ToString());
 
             // Restrict the secret columns to people in "G1", or users in "G2" can see everything but only for SecretPriority < 1 items.
             SecureSampleDB(db);
@@ -171,25 +171,25 @@ namespace Arriba.Test.Model
             // Run the Query as a user in all column restriction groups
             // Verify the query is unrestricted - no WHERE clause and no filtered columns
             result = db.Query(new AggregationQuery(q), (si) => si.Name == "g1" || si.Name == "g2");
-            Assert.AreEqual("*:One", result.Query.Where.ToString());
+            Assert.AreEqual("[*]:One", result.Query.Where.ToString());
             Assert.IsFalse(HasRestrictedClauses(result.Query.Where));
 
             // Run the Query as a user in G3.
             // Verify WHERE clause restriction.
             result = db.Query(new AggregationQuery(q), (si) => si.Name == "g3");
-            Assert.AreEqual("(SecretPriority > 1 AND *:One)", result.Query.Where.ToString());
+            Assert.AreEqual("[SecretPriority] > 1 AND [*]:One", result.Query.Where.ToString());
             Assert.IsFalse(HasRestrictedClauses(result.Query.Where));
 
             // Run the Query as a user in all groups
             // Verify WHERE clause restriction for *first* matching group
             result = db.Query(new AggregationQuery(q), (si) => true);
-            Assert.AreEqual("(SecretPriority > 1 AND *:One)", result.Query.Where.ToString());
+            Assert.AreEqual("[SecretPriority] > 1 AND [*]:One", result.Query.Where.ToString());
             Assert.IsFalse(HasRestrictedClauses(result.Query.Where));
 
             // Run the Query as a user in no groups.
             // Verify all column restrictions, no where clause filter
             result = db.Query(new AggregationQuery(q), (si) => false);
-            Assert.AreEqual("*:One", result.Query.Where.ToString());
+            Assert.AreEqual("[*]:One", result.Query.Where.ToString());
             Assert.IsTrue(HasRestrictedClauses(result.Query.Where));
 
             // Add a query clause for a disallowed column when not in group. Verify error.
@@ -200,7 +200,7 @@ namespace Arriba.Test.Model
 
             // Add a query clause for a disallowed column when in group. Verify success.
             result = db.Query(new AggregationQuery(q) { Where = QueryParser.Parse("One AND SecretOwner=Bob") }, (si) => si.Name == "g1");
-            Assert.AreEqual("(*:One AND SecretOwner = Bob)", result.Query.Where.ToString());
+            Assert.AreEqual("[*]:One AND [SecretOwner] = Bob", result.Query.Where.ToString());
             Assert.IsTrue(HasRestrictedClauses(result.Query.Where));
 
             // Ask to aggregate on a restricted column. Verify error.
@@ -217,7 +217,6 @@ namespace Arriba.Test.Model
             Assert.AreEqual("", result.Query.Where.ToString());
             Assert.IsFalse(result.Details.Succeeded);
             Assert.AreEqual(String.Format(ExecutionDetails.DisallowedColumnQuery, "SecretPriority"), result.Details.Errors);
-
         }
 
         [TestMethod]
@@ -239,7 +238,7 @@ namespace Arriba.Test.Model
             q.Where = QueryParser.Parse("SecretPriority = 1 AND SecretOwner = #Q2[SecretOwner]");
             result = db.Query(q, (si) => si.Name == "g1" || si.Name == "g2");
             Assert.IsTrue(result.Details.Succeeded);
-            Assert.AreEqual("(SecretPriority = 1 AND SecretOwner = IN(Bob, Bob, Bob))", result.Query.Where.ToString());
+            Assert.AreEqual("[SecretPriority] = 1 AND [SecretOwner] = IN(Bob, Bob, Bob)", result.Query.Where.ToString());
 
             // Run a JOIN with a disallowed clause on the top query - verify error
             q.Where = QueryParser.Parse("SecretPriority = 1 AND SecretOwner = #Q1[SecretOwner]");
@@ -266,7 +265,7 @@ namespace Arriba.Test.Model
             q.Where = QueryParser.Parse("ID > 1 AND ID = #Q1[ID]");
             result = db.Query(q, (si) => false);
             Assert.IsTrue(result.Details.Succeeded);
-            Assert.AreEqual("(ID > 1 AND ID = IN(1))", result.Query.Where.ToString());
+            Assert.AreEqual("[ID] > 1 AND [ID] = IN(1)", result.Query.Where.ToString());
         }
 
         [TestMethod]
@@ -298,7 +297,7 @@ namespace Arriba.Test.Model
             // Run the Query when the user has a row restriction. Verify success with row restrictor.
             result = db.Query(c, (si) => si.Name == "g3");
             Assert.IsTrue(result.Details.Succeeded);
-            Assert.AreEqual("(SecretPriority > 1 AND *:One)", result.Query.Where.ToString());
+            Assert.AreEqual("[SecretPriority] > 1 AND [*]:One", result.Query.Where.ToString());
 
             // Run the Query when the user has a column restriction. Verify error.
             result = db.Query(c, (si) => false);

--- a/Arriba/Arriba.Test/Model/TableTests.cs
+++ b/Arriba/Arriba.Test/Model/TableTests.cs
@@ -48,11 +48,11 @@ namespace Arriba.Test.Model
             // Verify all columns came back
             Assert.AreEqual(String.Join(", ", p.ColumnNames), String.Join(", ", p2.ColumnNames));
 
-            // Select top 3 bugs with Priority = 3 and ID <= 12000, order by ID
+            // Select top 3 bugs with Priority = 3 and [ID] <= 12000, order by [ID]
             SelectQuery query = new SelectQuery();
             query.Columns = new string[] { "ID", "Priority" };
             query.Count = 3;
-            query.Where = SelectQuery.ParseWhere("Priority = 3 AND ID <= 12000");
+            query.Where = SelectQuery.ParseWhere("Priority = 3 AND [ID] <= 12000");
             SelectResult result = p2.Query(query);
             Assert.AreEqual(2, (int)result.Total);
             Assert.AreEqual("11999", result.Values[0, 0].ToString());
@@ -132,9 +132,9 @@ namespace Arriba.Test.Model
                 (tbl) =>
                 {
                     tbl.AddColumn(new ColumnDetails("Color", "color", null));
-                    IUntypedColumn bugIdColumn = (tbl as Partition).Columns["Priority"];
+                    IUntypedColumn bugIDColumn = (tbl as Partition).Columns["Priority"];
                     IUntypedColumn colorColumn = (tbl as Partition).Columns["Color"];
-                    (colorColumn.InnerColumn as ColorColumn).LookupColumn = (IColumn<short>)bugIdColumn.InnerColumn;
+                    (colorColumn.InnerColumn as ColorColumn).LookupColumn = (IColumn<short>)bugIDColumn.InnerColumn;
                 });
         }
 
@@ -197,7 +197,7 @@ namespace Arriba.Test.Model
             t.AddOrUpdate(newData, new AddOrUpdateOptions() { Mode = AddOrUpdateMode.UpdateAndIgnoreAdds });
             Assert.AreEqual(5, (int)t.Count);
 
-            SelectQuery q = new SelectQuery() { Columns = new string[] { "Title" }, Count = 10, Where = SelectQuery.ParseWhere("ID = 11512") };
+            SelectQuery q = new SelectQuery() { Columns = new string[] { "Title" }, Count = 10, Where = SelectQuery.ParseWhere("[ID] = 11512") };
             SelectResult result = t.Query(q);
             Assert.AreEqual("Existing Item", result.Values[0, 0].ToString());
 
@@ -386,7 +386,7 @@ namespace Arriba.Test.Model
             SelectQuery selectQuery = new SelectQuery();
             selectQuery.Columns = new string[] { "ID", "Priority" };
             selectQuery.Count = 3;
-            selectQuery.Where = SelectQuery.ParseWhere("ID > -1");
+            selectQuery.Where = SelectQuery.ParseWhere("[ID] > -1");
             SelectResult selectResult = table.Query(selectQuery);
             Assert.AreEqual(0, (int)selectResult.Total);
 
@@ -433,7 +433,7 @@ namespace Arriba.Test.Model
             // Select top 3 bugs with Priority = 3 and ID <= 12000, order by ID
             query.Columns = new string[] { "ID", "Priority" };
             query.Count = 3;
-            query.Where = SelectQuery.ParseWhere("Priority = 3 AND ID <= 12000");
+            query.Where = SelectQuery.ParseWhere("Priority = 3 AND [ID] <= 12000");
             result = table.Query(query);
             Assert.AreEqual(2, (int)result.Total);
             Assert.AreEqual("11999", result.Values[0, 0].ToString());
@@ -569,7 +569,7 @@ namespace Arriba.Test.Model
 
             // Verify the result converts to a dimension properly
             AggregationDimension dimension = result.ToAggregationDimension();
-            Assert.AreEqual("Query [Priority = 0,Priority = 1,Priority = 3]", dimension.ToString());
+            Assert.AreEqual("Query [[Priority] = 0,[Priority] = 1,[Priority] = 3]", dimension.ToString());
 
             // Verify distinct priority where priority is not 1 has only two values
             query.Where = QueryParser.Parse("Priority != 1");
@@ -622,7 +622,7 @@ namespace Arriba.Test.Model
 
             // Verify the result converts to a dimension properly
             AggregationDimension dimension = result.ToAggregationDimension();
-            Assert.AreEqual("Query [Priority = 3,Priority = 0]", dimension.ToString());
+            Assert.AreEqual("Query [[Priority] = 3,[Priority] = 0]", dimension.ToString());
 
             // Verify if we only ask for one value, query reports more values left
             query.Count = 1;
@@ -653,8 +653,8 @@ namespace Arriba.Test.Model
             query.Dimensions.Add(new AggregationDimension("Priority", "Priority < 2", "Priority >= 2"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Priority < 2, 2
-Priority >= 2, 2
+[Priority] < 2, 2
+[Priority] >= 2, 2
 , 4");
             Assert.AreEqual((ulong)2, result.Values[0, 1]);
             Assert.AreEqual((ulong)2, result.Values[1, 1]);
@@ -664,45 +664,45 @@ Priority >= 2, 2
             query.Dimensions.Add(new AggregationDimension("Title", "Title:One | Title:Two", "-(Title:One | Title:Two)"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Priority < 2, (Title:One OR Title:Two), 1
-Priority < 2, NOT((Title:One OR Title:Two)), 1
-Priority < 2, , 2
-Priority >= 2, (Title:One OR Title:Two), 1
-Priority >= 2, NOT((Title:One OR Title:Two)), 1
-Priority >= 2, , 2
-, (Title:One OR Title:Two), 2
-, NOT((Title:One OR Title:Two)), 2
+[Priority] < 2, [Title]:One OR [Title]:Two, 1
+[Priority] < 2, NOT([Title]:One OR [Title]:Two), 1
+[Priority] < 2, , 2
+[Priority] >= 2, [Title]:One OR [Title]:Two, 1
+[Priority] >= 2, NOT([Title]:One OR [Title]:Two), 1
+[Priority] >= 2, , 2
+, [Title]:One OR [Title]:Two, 2
+, NOT([Title]:One OR [Title]:Two), 2
 , , 4
 ");
 
             // Sparse dimensions - verify skipping is correct
             query.Dimensions.Clear();
-            query.Dimensions.Add(new AggregationDimension("Priority", "Priority = 0", "Priority = 1", "Priority = 2", "Priority = 3"));
-            query.Dimensions.Add(new AggregationDimension("ID", "ID < 11900", "ID >= 11900"));
+            query.Dimensions.Add(new AggregationDimension("[Priority]", "[Priority] = 0", "[Priority] = 1", "[Priority] = 2", "[Priority] = 3"));
+            query.Dimensions.Add(new AggregationDimension("ID", "[ID] < 11900", "[ID] >= 11900"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Priority = 0, ID < 11900, 1
-Priority = 0, ID >= 11900, null
-Priority = 0, , 1
-Priority = 1, ID < 11900, null
-Priority = 1, ID >= 11900, 1
-Priority = 1, , 1
-Priority = 2, ID < 11900, null
-Priority = 2, ID >= 11900, null
-Priority = 2, , null
-Priority = 3, ID < 11900, 1
-Priority = 3, ID >= 11900, 1
-Priority = 3, , 2
-, ID < 11900, 2
-, ID >= 11900, 2
+[Priority] = 0, [ID] < 11900, 1
+[Priority] = 0, [ID] >= 11900, null
+[Priority] = 0, , 1
+[Priority] = 1, [ID] < 11900, null
+[Priority] = 1, [ID] >= 11900, 1
+[Priority] = 1, , 1
+[Priority] = 2, [ID] < 11900, null
+[Priority] = 2, [ID] >= 11900, null
+[Priority] = 2, , null
+[Priority] = 3, [ID] < 11900, 1
+[Priority] = 3, [ID] >= 11900, 1
+[Priority] = 3, , 2
+, [ID] < 11900, 2
+, [ID] >= 11900, 2
 , , 4
 ");
             // Add an empty cell and re-check
             query.Dimensions.Clear();
-            query.Dimensions.Add(new AggregationDimension("Title", "Title:unused"));
+            query.Dimensions.Add(new AggregationDimension("[Title]", "[Title]:unused"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Title:unused, null
+[Title]:unused, null
 , 4
 ");
         }
@@ -728,26 +728,26 @@ Title:unused, null
             Assert.AreEqual((long)47097, result.Values[0, 0]);
 
             // One dimension - verify values split out and are correct; dimension queries echoed
-            query.Dimensions.Add(new AggregationDimension("Priority", "Priority < 2", "Priority >= 2"));
+            query.Dimensions.Add(new AggregationDimension("[Priority]", "[Priority] < 2", "[Priority] >= 2"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Priority < 2, 23455
-Priority >= 2, 23642
+[Priority] < 2, 23455
+[Priority] >= 2, 23642
 , 47097
 ");
 
             // Two dimensions - verify values split on both; values are correct
-            query.Dimensions.Add(new AggregationDimension("Title", "Title:One | Title:Two", "-(Title:One | Title:Two)"));
+            query.Dimensions.Add(new AggregationDimension("[Title]", "[Title]:One | [Title]:Two", "-([Title]:One | [Title]:Two)"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Priority < 2, (Title:One OR Title:Two), 11512
-Priority < 2, NOT((Title:One OR Title:Two)), 11943
-Priority < 2, , 23455
-Priority >= 2, (Title:One OR Title:Two), 11643
-Priority >= 2, NOT((Title:One OR Title:Two)), 11999
-Priority >= 2, , 23642
-, (Title:One OR Title:Two), 23155
-, NOT((Title:One OR Title:Two)), 23942
+[Priority] < 2, [Title]:One OR [Title]:Two, 11512
+[Priority] < 2, NOT([Title]:One OR [Title]:Two), 11943
+[Priority] < 2, , 23455
+[Priority] >= 2, [Title]:One OR [Title]:Two, 11643
+[Priority] >= 2, NOT([Title]:One OR [Title]:Two), 11999
+[Priority] >= 2, , 23642
+, [Title]:One OR [Title]:Two, 23155
+, NOT([Title]:One OR [Title]:Two), 23942
 , , 47097
 ");
 
@@ -756,7 +756,7 @@ Priority >= 2, , 23642
             query.Dimensions.Add(new AggregationDimension("Title", "Title:unused"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Title:unused, null
+[Title]:unused, null
 , 47097
 ");
         }
@@ -779,26 +779,26 @@ Title:unused, null
             Assert.AreEqual(11512, result.Values[0, 0]);
 
             // One dimension - verify values split out and are correct; dimension queries echoed
-            query.Dimensions.Add(new AggregationDimension("Priority", "Priority < 2", "Priority >= 2"));
+            query.Dimensions.Add(new AggregationDimension("[Priority]", "[Priority] < 2", "[Priority] >= 2"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Priority < 2, 11512
-Priority >= 2, 11643
+[Priority] < 2, 11512
+[Priority] >= 2, 11643
 , 11512
 ");
 
             // Two dimensions - verify values split on both; values are correct
-            query.Dimensions.Add(new AggregationDimension("Title", "Title:One | Title:Two", "-(Title:One | Title:Two)"));
+            query.Dimensions.Add(new AggregationDimension("[Title]", "[Title]:One | [Title]:Two", "-([Title]:One | [Title]:Two)"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Priority < 2, (Title:One OR Title:Two), 11512
-Priority < 2, NOT((Title:One OR Title:Two)), 11943
-Priority < 2, , 11512
-Priority >= 2, (Title:One OR Title:Two), 11643
-Priority >= 2, NOT((Title:One OR Title:Two)), 11999
-Priority >= 2, , 11643
-, (Title:One OR Title:Two), 11512
-, NOT((Title:One OR Title:Two)), 11943
+[Priority] < 2, [Title]:One OR [Title]:Two, 11512
+[Priority] < 2, NOT([Title]:One OR [Title]:Two), 11943
+[Priority] < 2, , 11512
+[Priority] >= 2, [Title]:One OR [Title]:Two, 11643
+[Priority] >= 2, NOT([Title]:One OR [Title]:Two), 11999
+[Priority] >= 2, , 11643
+, [Title]:One OR [Title]:Two, 11512
+, NOT([Title]:One OR [Title]:Two), 11943
 , , 11512
 ");
 
@@ -807,7 +807,7 @@ Priority >= 2, , 11643
             query.Dimensions.Add(new AggregationDimension("Title", "Title:unused"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Title:unused, null
+[Title]:unused, null
 , 11512");
         }
 
@@ -829,26 +829,26 @@ Title:unused, null
             Assert.AreEqual(11999, result.Values[0, 0]);
 
             // One dimension - verify values split out and are correct; dimension queries echoed
-            query.Dimensions.Add(new AggregationDimension("Priority", "Priority < 2", "Priority >= 2"));
+            query.Dimensions.Add(new AggregationDimension("[Priority]", "[Priority] < 2", "[Priority] >= 2"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Priority < 2, 11943
-Priority >= 2, 11999
+[Priority] < 2, 11943
+[Priority] >= 2, 11999
 , 11999
 ");
 
             // Two dimensions - verify values split on both; values are correct
-            query.Dimensions.Add(new AggregationDimension("Title", "Title:One | Title:Two", "-(Title:One | Title:Two)"));
+            query.Dimensions.Add(new AggregationDimension("[Title]", "[Title]:One | [Title]:Two", "-([Title]:One | [Title]:Two)"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Priority < 2, (Title:One OR Title:Two), 11512
-Priority < 2, NOT((Title:One OR Title:Two)), 11943
-Priority < 2, , 11943
-Priority >= 2, (Title:One OR Title:Two), 11643
-Priority >= 2, NOT((Title:One OR Title:Two)), 11999
-Priority >= 2, , 11999
-, (Title:One OR Title:Two), 11643
-, NOT((Title:One OR Title:Two)), 11999
+[Priority] < 2, [Title]:One OR [Title]:Two, 11512
+[Priority] < 2, NOT([Title]:One OR [Title]:Two), 11943
+[Priority] < 2, , 11943
+[Priority] >= 2, [Title]:One OR [Title]:Two, 11643
+[Priority] >= 2, NOT([Title]:One OR [Title]:Two), 11999
+[Priority] >= 2, , 11999
+, [Title]:One OR [Title]:Two, 11643
+, NOT([Title]:One OR [Title]:Two), 11999
 , , 11999
 ");
 
@@ -857,7 +857,7 @@ Priority >= 2, , 11999
             query.Dimensions.Add(new AggregationDimension("Title", "Title:unused"));
             result = table.Query(query);
             AssertBlockEquals(result.Values, @"
-Title:unused, null
+[Title]:unused, null
 , 11999");
         }
 
@@ -990,7 +990,7 @@ Title:unused, null
             table.AddColumn(new ColumnDetails("Title", "string", null, "t", false));
             table.AddColumn(new ColumnDetails("Priority", "short", -1, "p", false));
             table.AddColumn(new ColumnDetails("Created Date", "DateTime", DateTime.MinValue.ToUniversalTime(), "cd", false));
-            table.AddColumn(new ColumnDetails("Primary Bug ID", "int", -1, "pid", false));
+            table.AddColumn(new ColumnDetails("Primary Bug ID", "int", -1, "pID", false));
 
             table.AddColumn(new ColumnDetails("IsDuplicate", "bool", true, "", false));
             table.AddColumn(new ColumnDetails("ActiveTime", "TimeSpan", null, "at", false));

--- a/Arriba/Arriba/Model/Expressions/Expressions.cs
+++ b/Arriba/Arriba/Model/Expressions/Expressions.cs
@@ -46,7 +46,7 @@ namespace Arriba.Model.Expressions
 
         public override string ToString()
         {
-            return StringExtensions.Format("({0})", String.Join(" OR ", (IList<IExpression>)_set));
+            return String.Join(" OR ", (IList<IExpression>)_set);
         }
     }
 
@@ -99,7 +99,26 @@ namespace Arriba.Model.Expressions
 
         public override string ToString()
         {
-            return StringExtensions.Format("({0})", String.Join(" AND ", (IList<IExpression>)_set));
+            StringBuilder result = new StringBuilder();
+            foreach(IExpression part in _set)
+            {
+                if (result.Length > 0) result.Append(" AND ");
+
+                if(part is OrExpression)
+                {
+                    // Explicit parenthesis are only required on an OR expression inside and AND expression.
+                    // AND takes precedence over OR, so A OR B AND C OR D => (A OR (B AND C) OR D)
+                    result.Append("(");
+                    result.Append(part);
+                    result.Append(")");
+                }
+                else
+                {
+                    result.Append(part);
+                }
+            }
+
+            return result.ToString();
         }
     }
 
@@ -390,7 +409,7 @@ namespace Arriba.Model.Expressions
         public override string ToString()
         {
             StringBuilder result = new StringBuilder();
-            result.Append(this.ColumnName);
+            result.Append(QueryScanner.WrapColumnName(this.ColumnName));
             result.Append(this.Operator.ToSyntaxString());
             result.Append("IN(");
 
@@ -404,7 +423,7 @@ namespace Arriba.Model.Expressions
                     break;
                 }
 
-                result.Append(this.Values.GetValue(i).ToString());
+                result.Append(QueryScanner.WrapValue(this.Values.GetValue(i).ToString()));
             }
 
             result.Append(")");

--- a/Arriba/Arriba/Model/Query/QueryScanner.cs
+++ b/Arriba/Arriba/Model/Query/QueryScanner.cs
@@ -269,19 +269,6 @@ namespace Arriba.Model.Query
         /// <returns>Parsable version of column namwe</returns>
         public static string WrapColumnName(string columnName)
         {
-            bool shouldEscape = false;
-            for (int i = 0; i < columnName.Length; ++i)
-            {
-                char current = columnName[i];
-                if (Char.IsWhiteSpace(current) || current == ']')
-                {
-                    shouldEscape = true;
-                    break;
-                }
-            }
-
-            if (!shouldEscape) return columnName;
-
             return StringExtensions.Format("[{0}]", columnName.Replace("]", "]]"));
         }
 

--- a/Arriba/Databases/Sample/config.json
+++ b/Arriba/Databases/Sample/config.json
@@ -1,6 +1,9 @@
 ﻿{
 	/* See Arriba\Tools\Arriba.TfsWorkItemCrawler\CrawlerConfiguration.cs for all available properties. */
 
+	/* The Arriba Service URL to publish to. Replace with the real name for the server hosting your database. */
+	"arribaServiceUrl": "http://localhost:42784",
+
 	/* The name of the Arriba table to create for these items. */
 	"arribaTable": "Sample",
 
@@ -17,14 +20,19 @@
 	/* Which IItemProvider to use to populate the table */
 	"itemProvider": "TfsItemProvider",
 
+    /* Which IItemConsumer to write items to [ArribaClient, ArribaDirect, CsvWriter] */
+	"itemConsumer": "ArribaClient",
+
 	/* The Name or URL of the database to crawl. Use the VSO URL for TFS.
 	   ex: https://<myProject>.visualstudio.com */
 	"itemDatabaseName": "https://myProject.visualstudio.com",
 
 	/* Authentication Mode to use with provider (provider specific).
-       For TfsItemProvider: integrated (default), aad, alternate (deprecated) */
+       For TfsItemProvider: integrated (default), aad, alternate */
 	"authenticationMode":  "aad",
 
-    /* For TFS alternate authentication mode, include the user name. */
+    /* For TFS alternate authentication mode, include the user name. 
+	   Run Arriba.TfsWorkItemCrawler.exe <config> -Password to provide the password. 
+	   The password is encrypted with DPAPI for the current Windows user only. */
 	"userName": "user@domain.com"
 }

--- a/Arriba/Tools/Arriba.TfsWorkItemCrawler/Arriba.TfsWorkItemCrawler.csproj
+++ b/Arriba/Tools/Arriba.TfsWorkItemCrawler/Arriba.TfsWorkItemCrawler.csproj
@@ -160,6 +160,7 @@
     <Compile Include="CsvImporter.cs" />
     <Compile Include="DefaultCrawler.cs" />
     <Compile Include="ItemConsumers\ArribaClientIndexerItemConsumer.cs" />
+    <Compile Include="ItemConsumers\ItemConsumerUtilities.cs" />
     <Compile Include="ItemProviders\CsvReaderItemProvider.cs" />
     <Compile Include="ItemConsumers\ComposedItemConsumer.cs" />
     <Compile Include="ItemConsumers\CsvWriterItemConsumer.cs" />

--- a/Arriba/Tools/Arriba.TfsWorkItemCrawler/CrawlerConfiguration.cs
+++ b/Arriba/Tools/Arriba.TfsWorkItemCrawler/CrawlerConfiguration.cs
@@ -59,6 +59,11 @@ namespace Arriba.TfsWorkItemCrawler
         public string ItemProvider { get; set; }
 
         /// <summary>
+        ///  Name of IItemConsumer to write to on crawl. [ArribaClient, ArribaDirect, CsvWriter]
+        /// </summary>
+        public string ItemConsumer { get; set; }
+
+        /// <summary>
         ///  Name/Url of source database. [https://projectName.visualstudio.com]
         /// </summary>
         public string ItemDatabaseName { get; set; }
@@ -81,12 +86,6 @@ namespace Arriba.TfsWorkItemCrawler
         /// </summary>
         public string UserName { get; set; }
         
-        /// <summary>
-        ///  True to build the Arriba database in process rather than writing new and changed
-        ///  items to the live service URL
-        /// </summary>
-        public bool UseDirectConsumer { get; set; }
-
         /// <summary>
         ///  List of columns to be renamed from the source, if any.
         /// </summary>

--- a/Arriba/Tools/Arriba.TfsWorkItemCrawler/ItemConsumers/ItemConsumerUtilities.cs
+++ b/Arriba/Tools/Arriba.TfsWorkItemCrawler/ItemConsumers/ItemConsumerUtilities.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Arriba.TfsWorkItemCrawler.ItemConsumers
+{
+    public static class ItemConsumerUtilities
+    {
+        public static IItemConsumer Build(CrawlerConfiguration config)
+        {
+            if (config == null) throw new ArgumentNullException("config", "config is null.");
+
+            switch(config.ItemConsumer.ToLowerInvariant())
+            {
+                case "":
+                case "arribaclient":
+                    return new ArribaClientIndexerItemConsumer(config, config.ArribaServiceUrl ?? "http://localhost:42784");
+                case "arribadirect":
+                    return new ArribaDirectIndexerItemConsumer(config);
+                case "csvwriter":
+                    return new CsvWriterItemConsumer(config.ArribaTable, "Changed Date");
+                default:
+                    throw new InvalidOperationException(String.Format("{0} is an unknown Item Consumer", config.ItemConsumer));
+            }
+        }
+    }
+}

--- a/Arriba/Tools/Arriba.TfsWorkItemCrawler/ItemProviders/ItemProviderUtilities.cs
+++ b/Arriba/Tools/Arriba.TfsWorkItemCrawler/ItemProviders/ItemProviderUtilities.cs
@@ -12,18 +12,15 @@ namespace Arriba.TfsWorkItemCrawler.ItemProviders
 
         public static IItemProvider Build(CrawlerConfiguration config)
         {
-            if (config == null)
-            {
-                throw new ArgumentNullException("config", "config is null.");
-            }
+            if (config == null) throw new ArgumentNullException("config", "config is null.");
 
-            if (String.Equals(config.ItemProvider, "TfsItemProvider", StringComparison.InvariantCultureIgnoreCase))
+            switch (config.ItemProvider.ToLowerInvariant())
             {
-                return new TfsItemProvider(config);
-            }
-            else
-            {
-                throw new InvalidOperationException(String.Format("{0} is an unknown Item Provider", config.ItemProvider));
+                case "":
+                case "tfsitemprovider":
+                    return new TfsItemProvider(config);
+                default:
+                    throw new InvalidOperationException(String.Format("{0} is an unknown Item Provider", config.ItemProvider));
             }
         }
 

--- a/Arriba/Tools/Arriba.TfsWorkItemCrawler/Program.cs
+++ b/Arriba/Tools/Arriba.TfsWorkItemCrawler/Program.cs
@@ -34,8 +34,9 @@ namespace Arriba.TfsWorkItemCrawler
                         return -2;
                     }
 
-                    // Load the Configuration
+                    // Load the Configuration [up two or three folders, for Databases\<configurationName>\config.json
                     string configJsonPath = String.Format(@"..\..\Databases\{0}\config.json", configurationName);
+                    if (!File.Exists(configJsonPath)) configJsonPath = @"..\" + configJsonPath;
                     string configJson = File.ReadAllText(configJsonPath);
 
                     CrawlerConfiguration config = JsonConvert.DeserializeObject<CrawlerConfiguration>(configJson);
@@ -48,15 +49,7 @@ namespace Arriba.TfsWorkItemCrawler
                     }
 
                     // Build the item consumer
-                    IItemConsumer consumer;
-                    if (config.UseDirectConsumer)
-                    {
-                        consumer = new ArribaDirectIndexerItemConsumer(config);
-                    }
-                    else
-                    {
-                        consumer = new ArribaClientIndexerItemConsumer(config, config.ArribaServiceUrl ?? "http://localhost:42784");
-                    }
+                    IItemConsumer consumer = ItemConsumerUtilities.Build(config);
 
                     // Build the item provider
                     IItemProvider provider = ItemProviderUtilities.Build(config);


### PR DESCRIPTION
 - AllCounts endpoint returns query and parsed query.
  - IExpression.ToString will always wrap column names in braces (unambiguous).
  - IExpression.ToString only returns actually required parens.
  - Unit Test updates