### PR TITLE
Arriba: Don't camelCase dictionary keys.

### DIFF
--- a/Arriba/Arriba.Client/ArribaClient.cs
+++ b/Arriba/Arriba.Client/ArribaClient.cs
@@ -44,7 +44,7 @@ namespace Arriba.Client
 
             _serializerSettings = new JsonSerializerSettings()
             {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                ContractResolver = new CamelCasePropertyNamesContractResolver() { NamingStrategy = new CamelCaseNamingStrategy() { ProcessDictionaryKeys = false } },
                 Formatting = Debugger.IsAttached ? Formatting.Indented : Formatting.None
             };
 

--- a/Arriba/Arriba.Client/HttpExtensions.cs
+++ b/Arriba/Arriba.Client/HttpExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 
 using Arriba.Server;
@@ -17,7 +16,10 @@ namespace Arriba.Client
 {
     internal static class HttpExtensions
     {
-        private static JsonSerializerSettings s_jsonSettings = new JsonSerializerSettings() { ContractResolver = new CamelCasePropertyNamesContractResolver() };
+        private static JsonSerializerSettings s_jsonSettings = new JsonSerializerSettings()
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver() { NamingStrategy = new CamelCaseNamingStrategy() { ProcessDictionaryKeys = false } }
+        };
 
         public static async Task EnsureArribaSuccess(this HttpResponseMessage message)
         {

--- a/Arriba/Arriba.Client/Serialization/JSON/ByteBlockJsonConverter.cs
+++ b/Arriba/Arriba.Client/Serialization/JSON/ByteBlockJsonConverter.cs
@@ -7,7 +7,7 @@ using Arriba.Structures;
 
 using Newtonsoft.Json;
 
-namespace Arriba.Serialization.JSON
+namespace Arriba.Serialization.Json
 {
     /// <summary>
     /// JSON Serializer for Arriba ByteBlocks

--- a/Arriba/Arriba.Communication/ContentTypes/Json/JsonContentWriter.cs
+++ b/Arriba/Arriba.Communication/ContentTypes/Json/JsonContentWriter.cs
@@ -20,13 +20,14 @@ namespace Arriba.Communication.ContentTypes
 
         public JsonContentWriter(IEnumerable<JsonConverter> converters)
         {
-            _settings = new JsonSerializerSettings();
-#if DEBUG
-            _settings.Formatting = Newtonsoft.Json.Formatting.Indented;
-#endif
+            _settings = new JsonSerializerSettings()
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver() { NamingStrategy = new CamelCaseNamingStrategy() { ProcessDictionaryKeys = false } }
+            };
 
-            // Enable "PropertyName" to be output and read as "propertyName"
-            _settings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+            #if DEBUG
+            _settings.Formatting = Newtonsoft.Json.Formatting.Indented;
+            #endif
 
             foreach (var converter in converters)
             {


### PR DESCRIPTION
Fix allBasics (and all other endpoints) so that Dictionary keys don't get converted to camelCase, preserving exact table name casing.