### PR TITLE
Arriba Distribution Insights

### DIFF
--- a/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
+++ b/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace Arriba.Test.Model.Query
 {
@@ -270,15 +271,39 @@ namespace Arriba.Test.Model.Query
 
             // Values are suggested in order by frequency
             result = qi.GetIntelliSenseItems("[Student Count] = ", Tables);
-            Assert.AreEqual("100000, 10000, 1000", string.Join(", ", result.Suggestions.Select(ii => ii.Display)));
+            Assert.AreEqual("100000 70 %, 10000 20 %, 1000 10 %", ItemsAndCounts(result));
 
             // Values are filtered according to the query
             result = qi.GetIntelliSenseItems("[ID] < 15 AND [Student Count] = ", Tables);
-            Assert.AreEqual("1000, 10000", string.Join(", ", result.Suggestions.Select(ii => ii.Display)));
+            Assert.AreEqual("1000 67 %, 10000 33 %", ItemsAndCounts(result));
 
             // Distributions are returned for range operators
+            result = qi.GetIntelliSenseItems("[Student Count] < ", Tables);
+            Assert.AreEqual("1000 0 %, 15000 30 %, 29000 30 %, 43000 30 %, 57000 30 %, 71000 30 %, 100000 30 %", ItemsAndCounts(result));
+
             result = qi.GetIntelliSenseItems("[Student Count] <= ", Tables);
-            Assert.AreEqual("", string.Join(", ", result.Suggestions.Select(ii => ii.Display)));
+            Assert.AreEqual("1000 10 %, 15000 30 %, 29000 30 %, 43000 30 %, 57000 30 %, 71000 30 %, 100000 all", ItemsAndCounts(result));
+
+            result = qi.GetIntelliSenseItems("[Student Count] > ", Tables);
+            Assert.AreEqual("100000 0 %, 71000 70 %, 57000 70 %, 43000 70 %, 29000 70 %, 15000 70 %, 1000 90 %", ItemsAndCounts(result));
+
+            result = qi.GetIntelliSenseItems("[Student Count] >= ", Tables);
+            Assert.AreEqual("100000 70 %, 71000 70 %, 57000 70 %, 43000 70 %, 29000 70 %, 15000 70 %, 1000 all", ItemsAndCounts(result));
+
+            // Only provide type hint when no rows match the query
+            result = qi.GetIntelliSenseItems("[ID] < 0 AND [Student Count] >= ", Tables);
+            Assert.AreEqual(0, result.Suggestions.Count);
+        }
+
+        private static string ItemsAndCounts(IntelliSenseResult result)
+        {
+            StringBuilder output = new StringBuilder();
+            foreach(IntelliSenseItem item in result.Suggestions)
+            {
+                if (output.Length > 0) output.Append(", ");
+                output.Append($"{item.Display} {item.Hint}");
+            }
+            return output.ToString();
         }
 
         [TestMethod]

--- a/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
+++ b/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
@@ -278,17 +278,18 @@ namespace Arriba.Test.Model.Query
             Assert.AreEqual("1000 67 %, 10000 33 %", ItemsAndCounts(result));
 
             // Distributions are returned for range operators
+            // Only non-empty buckets are returned.
             result = qi.GetIntelliSenseItems("[Student Count] < ", Tables);
-            Assert.AreEqual("1000 0 %, 15000 30 %, 29000 30 %, 43000 30 %, 57000 30 %, 71000 30 %, 100000 30 %", ItemsAndCounts(result));
+            Assert.AreEqual("15000 30 %", ItemsAndCounts(result));
 
             result = qi.GetIntelliSenseItems("[Student Count] <= ", Tables);
-            Assert.AreEqual("1000 10 %, 15000 30 %, 29000 30 %, 43000 30 %, 57000 30 %, 71000 30 %, 100000 all", ItemsAndCounts(result));
+            Assert.AreEqual("1000 10 %, 15000 30 %, 100000 all", ItemsAndCounts(result));
 
             result = qi.GetIntelliSenseItems("[Student Count] > ", Tables);
-            Assert.AreEqual("100000 0 %, 71000 70 %, 57000 70 %, 43000 70 %, 29000 70 %, 15000 70 %, 1000 90 %", ItemsAndCounts(result));
+            Assert.AreEqual("71000 70 %, 1000 90 %", ItemsAndCounts(result));
 
             result = qi.GetIntelliSenseItems("[Student Count] >= ", Tables);
-            Assert.AreEqual("100000 70 %, 71000 70 %, 57000 70 %, 43000 70 %, 29000 70 %, 15000 70 %, 1000 all", ItemsAndCounts(result));
+            Assert.AreEqual("100000 70 %, 1000 all", ItemsAndCounts(result));
 
             // Only provide type hint when no rows match the query
             result = qi.GetIntelliSenseItems("[ID] < 0 AND [Student Count] >= ", Tables);

--- a/Arriba/Arriba/Arriba.csproj
+++ b/Arriba/Arriba/Arriba.csproj
@@ -88,6 +88,8 @@
     <Compile Include="Model\Column\ColumnDetails.cs" />
     <Compile Include="Model\Column\FastAddSortedColumn.cs" />
     <Compile Include="Model\Column\IpRangeColumn.cs" />
+    <Compile Include="Model\Query\DistributionQuery.cs" />
+    <Compile Include="Model\Query\PercentilesQuery.cs" />
     <Compile Include="Structures\IpRange.cs" />
     <Compile Include="Model\Correctors\ColumnSecurityCorrector.cs" />
     <Compile Include="Model\Correctors\JoinCorrector.cs" />

--- a/Arriba/Arriba/Model/Query/DistributionQuery.cs
+++ b/Arriba/Arriba/Model/Query/DistributionQuery.cs
@@ -1,0 +1,422 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Arriba.Model.Correctors;
+using Arriba.Model.Expressions;
+using Arriba.Structures;
+using Arriba.Extensions;
+
+namespace Arriba.Model.Query
+{
+    public class DistributionQuery : IQuery<DataBlockResult>
+    {
+        private Array Buckets { get; set; }
+
+        public bool Inclusive { get; set; }
+        public string Column { get; set; }
+        public string TableName { get; set; }
+        public IExpression Where { get; set; }
+        public bool RequireMerge => false;
+
+        public DistributionQuery() : base()
+        { }
+
+        public DistributionQuery(string columnName, string where, bool inclusive)
+        {
+            this.Column = columnName;
+            this.Where = QueryParser.Parse(where);
+            this.Inclusive = inclusive;
+        }
+
+        public void OnBeforeQuery(ITable table)
+        {
+            // Find approximate 10th and 90th percentile values for this query
+            PercentilesQuery pq = new PercentilesQuery();
+            pq.Column = this.Column;
+            pq.TableName = this.TableName;
+            pq.Where = this.Where;
+            pq.Percentiles = new double[] { 0.10, 0.90 };
+
+            DataBlockResult result = table.Query(pq);
+            if (result.Details.Succeeded)
+            {
+                Bucketer bucketer = NativeContainer.CreateTypedInstance<Bucketer>(typeof(Bucketer<>), ((Table)table).GetColumnType(this.Column));
+                this.Buckets = bucketer.GetBuckets(result.Values);
+            }
+        }
+
+        public void Correct(ICorrector corrector)
+        {
+            if (corrector == null) throw new ArgumentNullException("corrector");
+            this.Where = corrector.Correct(this.Where);
+        }
+
+        public DataBlockResult Compute(Partition p)
+        {
+            if (p == null) throw new ArgumentNullException("p");
+            DataBlockResult result = new DataBlockResult(this);
+
+            // Verify the column exists
+            if (!p.ContainsColumn(this.Column))
+            {
+                result.Details.AddError(ExecutionDetails.ColumnDoesNotExist, this.Column);
+                return result;
+            }
+
+            // Verify we were able to get percentile values
+            if(this.Buckets == null)
+            {
+                result.Details.AddError(ExecutionDetails.ColumnDoesNotSupportOperator, "percentile", this.Column);
+                return result;
+            }
+
+            // Find the set of items matching the where clause
+            ShortSet whereSet = new ShortSet(p.Count);
+            this.Where.TryEvaluate(p, whereSet, result.Details);
+
+            IUntypedColumn column = p.Columns[this.Column];
+
+            if (result.Details.Succeeded)
+            {
+                Bucketer bucketer = NativeContainer.CreateTypedInstance<Bucketer>(typeof(Bucketer<>), column.ColumnType);
+                result.Values = bucketer.Bucket(column.InnerColumn, whereSet, this.Buckets, this.Inclusive);
+                result.Total = whereSet.Count();
+            }
+
+            return result;
+        }
+
+        public DataBlockResult Merge(DataBlockResult[] partitionResults)
+        {
+            if (partitionResults == null) throw new ArgumentNullException("partitionResults");
+            if (partitionResults.Length == 0) throw new ArgumentException("Length==0 not supported", "partitionResults");
+            if (!partitionResults[0].Details.Succeeded) return partitionResults[0];
+
+            DataBlockResult mergedResult = new DataBlockResult(this);
+            mergedResult.Values = new DataBlock(new string[] { "Bucket", "RowCount" }, this.Buckets.Length + 1);
+
+            // Copy the first partition values
+            for (int i = 0; i < mergedResult.Values.RowCount; ++i)
+            {
+                mergedResult.Values[i, 0] = partitionResults[0].Values[i, 0];
+                mergedResult.Values[i, 1] = partitionResults[0].Values[i, 1];
+            }
+
+            mergedResult.Details.Merge(partitionResults[0].Details);
+            mergedResult.Total += partitionResults[0].Total;
+
+            // Add the rest
+            for (int partitionIndex = 1; partitionIndex < partitionResults.Length; ++partitionIndex)
+            {
+                DataBlockResult result = partitionResults[partitionIndex];
+
+                for (int i = 0; i < mergedResult.Values.RowCount; ++i)
+                {
+                    mergedResult.Values[i, 1] = (ulong)mergedResult.Values[i, 1] + (ulong)result.Values[i, 1];
+                }
+
+                mergedResult.Details.Merge(result.Details);
+                mergedResult.Total += result.Total;
+            }
+
+            return mergedResult;
+        }
+
+        private abstract class Bucketer
+        {
+            public abstract Array GetBuckets(DataBlock percentileResults);
+            public abstract DataBlock Bucket(IColumn column, ShortSet whereSet, Array buckets, bool inclusive);
+        }
+
+        private class Bucketer<T> : Bucketer where T : IComparable<T>
+        {
+            public override DataBlock Bucket(IColumn c, ShortSet whereSet, Array b, bool inclusive)
+            {
+                IColumn<T> column = (IColumn<T>)c;
+                T[] buckets = (T[])b;
+
+                DataBlock result = new DataBlock(new string[] { "Bucket", "RowCount" }, buckets.Length + 1);
+
+                ulong[] counts = new ulong[buckets.Length + 1];
+
+                if (inclusive)
+                {
+                    for (int i = 0; i < column.Count; ++i)
+                    {
+                        ushort lid = (ushort)i;
+                        if (whereSet.Contains(lid))
+                        {
+                            T value = column[lid];
+
+                            int j = 0;
+                            for (; j < buckets.Length; ++j)
+                            {
+                                if (value.CompareTo(buckets[j]) <= 0)
+                                {
+                                    counts[j]++;
+                                    break;
+                                }
+                            }
+
+                            if (j == buckets.Length) counts[buckets.Length]++;
+                        }
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < column.Count; ++i)
+                    {
+                        ushort lid = (ushort)i;
+                        if (whereSet.Contains(lid))
+                        {
+                            T value = column[lid];
+
+                            int j = 0;
+                            for (; j < buckets.Length; ++j)
+                            {
+                                if (value.CompareTo(buckets[j]) < 0)
+                                {
+                                    counts[j]++;
+                                    break;
+                                }
+                            }
+
+                            if (j == buckets.Length) counts[buckets.Length]++;
+                        }
+                    }
+                }
+
+                for (int i = 0; i < buckets.Length; ++i)
+                {
+                    result[i, 0] = buckets[i];
+                    result[i, 1] = counts[i];
+                }
+
+                result[buckets.Length, 0] = null;
+                result[buckets.Length, 1] = counts[buckets.Length];
+
+                return result;
+            }
+
+            public override Array GetBuckets(DataBlock percentileResults)
+            {
+                T[] buckets = new T[7];
+
+                buckets[0] = (T)percentileResults[0, 1];
+                buckets[6] = (T)percentileResults[1, 1];
+
+                // Cast to a specific type at the array level to avoid per item casting
+                if (typeof(T).Equals(typeof(long)))
+                {
+                    GetBucketsLong((long[])(Array)buckets);
+                }
+                else if (typeof(T).Equals(typeof(int)))
+                {
+                    GetBucketsInt((int[])(Array)buckets);
+                }
+                //else if (typeof(T).Equals(typeof(short)))
+                //{
+                //    GetBucketsShort((short[])(Array)buckets);
+                //}
+                //else if (typeof(T).Equals(typeof(byte)))
+                //{
+                //    GetBucketsByte((byte[])(Array)buckets);
+                //}
+                //else if (typeof(T).Equals(typeof(ulong)))
+                //{
+                //    GetBucketsULong((ulong[])(Array)buckets);
+                //}
+                else if (typeof(T).Equals(typeof(uint)))
+                {
+                    GetBucketsUint((uint[])(Array)buckets);
+                }
+                //else if (typeof(T).Equals(typeof(ushort)))
+                //{
+                //    GetBucketsUShort((ushort[])(Array)buckets);
+                //}
+                //else if (typeof(T).Equals(typeof(double)))
+                //{
+                //    GetBucketsDouble((double[])(Array)buckets);
+                //}
+                //else if (typeof(T).Equals(typeof(float)))
+                //{
+                //    GetBucketsFloat((float[])(Array)buckets);
+                //}
+                else if (typeof(T).Equals(typeof(DateTime)))
+                {
+                    GetBucketsDateTime((DateTime[])(Array)buckets);
+                }
+                else if (typeof(T).Equals(typeof(TimeSpan)))
+                {
+                    GetBucketsTimeSpan((TimeSpan[])(Array)buckets);
+                }
+                else
+                {
+                    throw new NotImplementedException(StringExtensions.Format("{0} is unable to aggregate type {1}.", this.GetType().Name, buckets.GetValue(0).GetType().Name));
+                }
+
+                return buckets;
+            }
+
+            private static TimeSpan[] GetBucketsTimeSpan(TimeSpan[] buckets)
+            {
+                // Find the range and interval between buckets
+                TimeSpan range = buckets[buckets.Length - 1] - buckets[0];
+                TimeSpan interval = TimeSpan.FromTicks(range.Ticks / buckets.Length);
+
+                // Round the buckets
+                if(interval.TotalDays >= buckets.Length)
+                {
+                    buckets[0] = TimeSpan.FromDays(Math.Round(buckets[0].TotalDays));
+                    buckets[buckets.Length - 1] = TimeSpan.FromDays(Math.Round(buckets[buckets.Length - 1].TotalDays));
+                    interval = TimeSpan.FromDays(Math.Round(interval.TotalDays));
+                }
+                else if(interval.TotalHours >= buckets.Length)
+                {
+                    buckets[0] = TimeSpan.FromHours(Math.Round(buckets[0].TotalHours));
+                    buckets[buckets.Length - 1] = TimeSpan.FromHours(Math.Round(buckets[buckets.Length - 1].TotalHours));
+                    interval = TimeSpan.FromHours(Math.Round(interval.TotalHours));
+                }
+                else
+                {
+                    buckets[0] = TimeSpan.FromMinutes(Math.Round(buckets[0].TotalMinutes));
+                    buckets[buckets.Length - 1] = TimeSpan.FromMinutes(Math.Round(buckets[buckets.Length - 1].TotalMinutes));
+                    interval = TimeSpan.FromMinutes(Math.Round(interval.TotalMinutes));
+                }
+
+                // Set the buckets
+                for(int i = 1; i < buckets.Length - 1; ++i)
+                {
+                    buckets[i] = buckets[i - 1] + interval;
+                }
+
+                return buckets;
+            }
+
+            private static DateTime[] GetBucketsDateTime(DateTime[] buckets)
+            {
+                // Find the range and interval between buckets
+                TimeSpan range = buckets[buckets.Length - 1] - buckets[0];
+                TimeSpan interval = TimeSpan.FromTicks(range.Ticks / buckets.Length);
+
+                // Round the buckets
+                if (interval.TotalDays >= buckets.Length)
+                {
+                    buckets[0] = buckets[0].Date;
+                    buckets[buckets.Length - 1] = buckets[buckets.Length - 1].Date;
+                    interval = TimeSpan.FromDays(Math.Round(interval.TotalDays));
+                }
+                else if (interval.TotalHours >= buckets.Length)
+                {
+                    buckets[0] = buckets[0].Date.AddHours(Math.Round(buckets[0].TimeOfDay.TotalHours));
+                    buckets[buckets.Length - 1] = buckets[buckets.Length - 1].Date.AddHours(Math.Round(buckets[buckets.Length - 1].TimeOfDay.TotalHours));
+                    interval = TimeSpan.FromDays(Math.Round(interval.TotalDays));
+                }
+                else
+                {
+                    buckets[0] = buckets[0].Date.AddMinutes(Math.Round(buckets[0].TimeOfDay.TotalMinutes));
+                    buckets[buckets.Length - 1] = buckets[buckets.Length - 1].Date.AddMinutes(Math.Round(buckets[buckets.Length - 1].TimeOfDay.TotalMinutes));
+                    interval = TimeSpan.FromHours(Math.Round(interval.TotalHours));
+                    interval = TimeSpan.FromMinutes(Math.Round(interval.TotalMinutes));
+                }
+
+                // Set the buckets
+                for (int i = 1; i < buckets.Length - 1; ++i)
+                {
+                    buckets[i] = buckets[i - 1] + interval;
+                }
+
+                return buckets;
+            }
+
+            private static int[] GetBucketsInt(int[] buckets)
+            {
+                // Find the range and interval between buckets
+                int range = buckets[buckets.Length - 1] - buckets[0];
+                int interval = range / buckets.Length;
+
+                // Round the buckets
+                int scale = 10;
+                while(interval > scale * 10)
+                {
+                    scale *= 10;
+                }
+
+                if(scale > 10)
+                {
+                    buckets[0] -= buckets[0] % scale;
+                    buckets[buckets.Length - 1] -= buckets[buckets.Length - 1] % scale;
+                    interval -= interval % scale;
+                }
+
+                // Set the buckets
+                for (int i = 1; i < buckets.Length - 1; ++i)
+                {
+                    buckets[i] = buckets[i - 1] + interval;
+                }
+
+                return buckets;
+            }
+
+            private static uint[] GetBucketsUint(uint[] buckets)
+            {
+                // Find the range and uinterval between buckets
+                uint range = buckets[buckets.Length - 1] - buckets[0];
+                uint interval = range / (uint)buckets.Length;
+
+                // Round the buckets
+                uint scale = 10;
+                while (interval > scale * 10)
+                {
+                    scale *= 10;
+                }
+
+                if (scale > 10)
+                {
+                    buckets[0] -= buckets[0] % scale;
+                    buckets[buckets.Length - 1] -= buckets[buckets.Length - 1] % scale;
+                    interval -= interval % scale;
+                }
+
+                // Set the buckets
+                for (int i = 1; i < buckets.Length - 1; ++i)
+                {
+                    buckets[i] = buckets[i - 1] + interval;
+                }
+
+                return buckets;
+            }
+
+            private static long[] GetBucketsLong(long[] buckets)
+            {
+                // Find the range and longerval between buckets
+                long range = buckets[buckets.Length - 1] - buckets[0];
+                long interval = range / (long)buckets.Length;
+
+                // Round the buckets
+                long scale = 10;
+                while (interval > scale * 10)
+                {
+                    scale *= 10;
+                }
+
+                if (scale > 10)
+                {
+                    buckets[0] -= buckets[0] % scale;
+                    buckets[buckets.Length - 1] -= buckets[buckets.Length - 1] % scale;
+                    interval -= interval % scale;
+                }
+
+                // Set the buckets
+                for (int i = 1; i < buckets.Length - 1; ++i)
+                {
+                    buckets[i] = buckets[i - 1] + interval;
+                }
+
+                return buckets;
+            }
+        }
+    }
+}

--- a/Arriba/Arriba/Model/Query/PercentilesQuery.cs
+++ b/Arriba/Arriba/Model/Query/PercentilesQuery.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Arriba.Model.Correctors;
+using Arriba.Model.Expressions;
+using Arriba.Structures;
+
+namespace Arriba.Model.Query
+{
+    /// <summary>
+    ///  PercentilesQuery returns the requested percentiles for a query by sampling values
+    ///  and getting the medians across partitions.
+    /// </summary>
+    public class PercentilesQuery : IQuery<DataBlockResult>
+    {
+        public string Column { get; set; }
+        public double[] Percentiles { get; set; }
+
+        public string TableName { get; set; }
+        public IExpression Where { get; set; }
+        public bool RequireMerge => false;
+
+        public PercentilesQuery() : base()
+        { }
+
+        public PercentilesQuery(string column, string where, double[] percentiles)
+        {
+            this.Column = column;
+            this.Where = QueryParser.Parse(where);
+            this.Percentiles = percentiles;
+        }
+
+        public void OnBeforeQuery(ITable table)
+        { }
+
+        public void Correct(ICorrector corrector)
+        {
+            if (corrector == null) throw new ArgumentNullException("corrector");
+            this.Where = corrector.Correct(this.Where);
+        }
+
+        public DataBlockResult Compute(Partition p)
+        {
+            if (p == null) throw new ArgumentNullException("p");
+
+            DataBlockResult result = new DataBlockResult(this);
+
+            // Verify the column exists
+            if (!p.ContainsColumn(this.Column))
+            {
+                result.Details.AddError(ExecutionDetails.ColumnDoesNotExist, this.Column);
+                return result;
+            }
+
+            // Find the set of items matching the where clause
+            ShortSet whereSet = new ShortSet(p.Count);
+            this.Where.TryEvaluate(p, whereSet, result.Details);
+
+            int matchCount = whereSet.Count();
+            result.Total = matchCount;
+
+            if (result.Details.Succeeded && matchCount > 0)
+            {
+                // Get sample values
+                object[] samples = GetColumnSamples(p, p.Columns[this.Column], whereSet, matchCount);
+
+                // Sort them
+                Array.Sort(samples);
+
+                // Record the values corresponding to those percentiles
+                result.Values = new DataBlock(new string[] { "Percentiles", "Values" }, this.Percentiles.Length);
+
+                for (int i = 0; i < this.Percentiles.Length; ++i)
+                {
+                    double percentile = this.Percentiles[i];
+                    int sampleRow = (int)(percentile * samples.Length) - 1;
+                    if (sampleRow < 0) sampleRow = 0;
+                    if (sampleRow >= samples.Length) sampleRow = samples.Length - 1;
+
+                    result.Values[i, 0] = percentile;
+                    result.Values[i, 1] = samples[sampleRow];
+                }
+            }
+
+            return result;
+        }
+
+        private static object[] GetColumnSamples(Partition p, IUntypedColumn column, ShortSet whereSet, int matchCount)
+        {
+            // Get up to 500 samples
+            int countToGet = Math.Min(500, matchCount);
+
+            object[] samples = new object[countToGet];
+
+            Random r = new Random();
+            int sampleCount = 0;
+            int countLeft = matchCount;
+            for (int i = 0; i < p.Count && sampleCount < countToGet; ++i)
+            {
+                ushort lid = (ushort)i;
+
+                if (whereSet.Contains(lid))
+                {
+                    double excludeChance = r.NextDouble();
+                    int countNeeded = countToGet - sampleCount;
+
+                    // == if((countNeeded / countLeft) > excludeChance)
+                    if (countNeeded > (excludeChance * countLeft))
+                    {
+                        samples[sampleCount] = column[lid];
+                        sampleCount++;
+                    }
+
+                    countLeft--;
+                }
+            }
+
+            return samples;
+        }
+
+        public DataBlockResult Merge(DataBlockResult[] partitionResults)
+        {
+            if (partitionResults == null) throw new ArgumentNullException("partitionResults");
+            if (partitionResults.Length == 0) throw new ArgumentException("Length==0 not supported", "partitionResults");
+            if (!partitionResults[0].Details.Succeeded) return partitionResults[0];
+
+            DataBlockResult mergedResult = new DataBlockResult(this);
+            mergedResult.Values = new DataBlock(new string[] { "Percentiles", "Values" }, this.Percentiles.Length);
+
+            // Find the median for each percentile across partitions
+            object[] valuesPerPartition = new object[partitionResults.Length];
+            for (int i = 0; i < this.Percentiles.Length; ++i)
+            {
+                for (int partitionIndex = 0; partitionIndex < partitionResults.Length; ++partitionIndex)
+                {
+                    valuesPerPartition[partitionIndex] = partitionResults[partitionIndex].Values[i, 1];
+                }
+
+                Array.Sort(valuesPerPartition);
+
+                mergedResult.Values[i, 0] = this.Percentiles[i];
+                mergedResult.Values[i, 1] = valuesPerPartition[valuesPerPartition.Length / 2];
+            }
+
+            // Merge totals and details
+            for (int partitionIndex = 0; partitionIndex < partitionResults.Length; ++partitionIndex)
+            {
+                DataBlockResult result = partitionResults[partitionIndex];
+                mergedResult.Details.Merge(result.Details);
+                mergedResult.Total += result.Total;
+            }
+
+            return mergedResult;
+        }
+    }
+}

--- a/Arriba/Arriba/Model/Query/QueryIntelliSense.cs
+++ b/Arriba/Arriba/Model/Query/QueryIntelliSense.cs
@@ -453,7 +453,6 @@ namespace Arriba.Model.Query
         {
             Table singleTable;
             ColumnDetails singleColumn;
-            TryFindSingleMatchingColumn(targetTables, lastTerm, out singleTable, out singleColumn);
 
             if (!TryFindSingleMatchingColumn(targetTables, lastTerm, out singleTable, out singleColumn))
             {

--- a/Arriba/Arriba/Model/Query/QueryIntelliSense.cs
+++ b/Arriba/Arriba/Model/Query/QueryIntelliSense.cs
@@ -555,16 +555,16 @@ namespace Arriba.Model.Query
 
                 for (int i = distribution.Values.RowCount - 2; i >= 0; --i)
                 {
-                    string value = distribution.Values[i, 0].ToString();
+                    string value = QueryScanner.WrapValue(distribution.Values[i, 0].ToString());
                     double frequency = (double)countSoFar / (double)(distribution.Total);
+                    ulong countForRange = (ulong)distribution.Values[i, 1];
 
-                    if (value.StartsWith(guidance.Value, StringComparison.OrdinalIgnoreCase))
+                    if ((ulong)distribution.Values[i+1, 1] > 0 && value.StartsWith(guidance.Value, StringComparison.OrdinalIgnoreCase))
                     {
                         string hint = (countSoFar == (ulong)distribution.Total ? "all" : frequency.ToString("P0"));
-                        suggestions.Add(new IntelliSenseItem(QueryTokenCategory.Value, QueryScanner.WrapValue(value), hint));
+                        suggestions.Add(new IntelliSenseItem(QueryTokenCategory.Value, value, hint));
                     }
-
-                    ulong countForRange = (ulong)distribution.Values[i, 1];
+                    
                     countSoFar += countForRange;
                 }
             }
@@ -574,16 +574,16 @@ namespace Arriba.Model.Query
 
                 for (int i = 0; i < distribution.Values.RowCount - 1; ++i)
                 {
-                    string value = distribution.Values[i, 0].ToString();
+                    string value = QueryScanner.WrapValue(distribution.Values[i, 0].ToString());
                     ulong countForRange = (ulong)distribution.Values[i, 1];
                     countSoFar += countForRange;
 
                     double frequency = (double)countSoFar / (double)(distribution.Total);
 
-                    if (value.StartsWith(guidance.Value, StringComparison.OrdinalIgnoreCase))
+                    if (countForRange > 0 && value.StartsWith(guidance.Value, StringComparison.OrdinalIgnoreCase))
                     {
                         string hint = (countSoFar == (ulong)distribution.Total ? "all" : frequency.ToString("P0"));
-                        suggestions.Add(new IntelliSenseItem(QueryTokenCategory.Value, QueryScanner.WrapValue(value), hint));
+                        suggestions.Add(new IntelliSenseItem(QueryTokenCategory.Value, value, hint));
                     }
                 }
             }


### PR DESCRIPTION
Arriba Inline Insights now returns distributions when range operators are used.

- 10th and 90th percentile values are found.
- Values are rounded.
- Five equal sized buckets are added between the two values.
- Matching rows within each range are counted.
- Non-empty ranges are returned with the correct percentage which will match the resulting query.