### PR TITLE
Telemetry and Fixes

### DIFF
--- a/Arriba/Arriba.Communication/Server/Application/ArribaQueryApplication.cs
+++ b/Arriba/Arriba.Communication/Server/Application/ArribaQueryApplication.cs
@@ -500,7 +500,7 @@ namespace Arriba.Server
 
                 if (dimensionParts.Count == 1 && dimensionParts[0].EndsWith(">"))
                 {
-                    query.Dimensions.Add(new DistinctValueDimension(dimensionParts[0].TrimEnd('>')));
+                    query.Dimensions.Add(new DistinctValueDimension(QueryParser.UnwrapColumnName(dimensionParts[0].TrimEnd('>'))));
                 }
                 else
                 {

--- a/Arriba/Arriba.Test/Model/Query/QueryParserTests.cs
+++ b/Arriba/Arriba.Test/Model/Query/QueryParserTests.cs
@@ -243,11 +243,40 @@ namespace Arriba.Test.Model.Query
         }
 
         [TestMethod]
-        public void ValuesContainingKeywords()
+        public void QueryParser_ValuesContainingKeywords()
         {
             // Try terms which start with, contain, or end with keywords (NOT, AND, OR)
             Assert.AreEqual("[*]:noted AND [*]:corn AND [*]:sandwiches", QueryParser.Parse("noted corn sandwiches").ToString());
             Assert.AreEqual("[*]:org AND [*]:constructor", QueryParser.Parse("org constructor").ToString());
+        }
+
+        [TestMethod]
+        public void QueryParser_EscapeAndUnescape()
+        {
+            Assert.AreEqual("", QueryParser.WrapColumnName(null));
+            Assert.AreEqual("", QueryParser.WrapColumnName(""));
+            Assert.AreEqual("[One]", QueryParser.WrapColumnName("One"));
+            Assert.AreEqual("[Owner [Ops]]]", QueryParser.WrapColumnName("Owner [Ops]"));
+
+            Assert.AreEqual("\"\"", QueryParser.WrapValue(null));
+            Assert.AreEqual("\"\"", QueryParser.WrapValue(""));
+            Assert.AreEqual("Simple", QueryParser.WrapValue("Simple"));
+            Assert.AreEqual("\"Bilbo \"\"Ringbearer\"\" Baggins\"", QueryParser.WrapValue("Bilbo \"Ringbearer\" Baggins"));
+
+            Assert.AreEqual("", QueryParser.UnwrapColumnName(null));
+            Assert.AreEqual("", QueryParser.UnwrapColumnName(""));
+            Assert.AreEqual("One", QueryParser.UnwrapColumnName("One"));
+            Assert.AreEqual("One", QueryParser.UnwrapColumnName("[One]"));
+            Assert.AreEqual("Owner [Ops]", QueryParser.UnwrapColumnName("[Owner [Ops]]]"));
+            Assert.AreEqual("Owner [[Ops]]", QueryParser.UnwrapColumnName("[Owner [[Ops]]]]]"));
+
+            Assert.AreEqual("", QueryParser.UnwrapValue(null));
+            Assert.AreEqual("", QueryParser.UnwrapValue(""));
+            Assert.AreEqual("", QueryParser.UnwrapValue("\"\""));
+            Assert.AreEqual("Simple", QueryParser.UnwrapValue("Simple"));
+            Assert.AreEqual("Simple", QueryParser.UnwrapValue("\"Simple\""));
+            Assert.AreEqual("Bilbo \"Ringbearer\" Baggins", QueryParser.UnwrapValue("\"Bilbo \"\"Ringbearer\"\" Baggins\""));
+            Assert.AreEqual("\"\"\"", QueryParser.UnwrapValue("\"\"\"\"\"\"\""));
         }
     }
 }

--- a/Arriba/Arriba.Web/js/utilities.js
+++ b/Arriba/Arriba.Web/js/utilities.js
@@ -125,12 +125,29 @@ Storage.prototype.dispatch = function(keyName) {
     window.dispatchEvent(new e("storage", { key: keyName }));
 }
 
+
 // Highlight values surrounded by Pi characters by wrapping them in <span class="h"></span>
 function highlight(value) {
     var replacement = '<span class="h">$1</span>';
 
     if (value !== undefined) {
-        return { __html: unescape(value.toString()).replace(highlightRangeRegex, replacement) };
+        // Escape the content to ensure it's not html
+        var escaper = document.createElement("div");
+        escaper.innerText = value;
+        var escaped = escaper.innerHTML;
+
+        return { __html: escaped.replace(highlightRangeRegex, replacement) };
+    }
+
+    return { __html: "" };
+};
+
+// Highlight surrounded by Pi characters by wrapping them in <span class="h"></span>
+function highlightHtml(value) {
+    var replacement = '<span class="h">$1</span>';
+
+    if (value !== undefined) {
+        return { __html: value.toString().replace(highlightRangeRegex, replacement) };
     }
 
     return { __html: "" };

--- a/Arriba/Arriba.Web/parts.optional/WorkItemDetails/WorkItemDetails.jsx
+++ b/Arriba/Arriba.Web/parts.optional/WorkItemDetails/WorkItemDetails.jsx
@@ -37,10 +37,10 @@ export default React.createClass({
         }
 
         var description = null;
-        if(this.props.data["Description"]) description = <div className="box" dangerouslySetInnerHTML={highlight(this.props.data["Description"])}></div>;
+        if(this.props.data["Description"]) description = <div className="box" dangerouslySetInnerHTML={highlightHtml(this.props.data["Description"])}></div>;
 
         var reproSteps = null;
-        if(this.props.data["Repro Steps"]) reproSteps = <div className="box" dangerouslySetInnerHTML={highlight(this.props.data["Repro Steps"])}></div>;
+        if(this.props.data["Repro Steps"]) reproSteps = <div className="box" dangerouslySetInnerHTML={highlightHtml(this.props.data["Repro Steps"])}></div>;
 
         return (
             <div className="details">

--- a/Arriba/Arriba.Web/parts.optional/WorkItemDetails/WorkItemHistory.jsx
+++ b/Arriba/Arriba.Web/parts.optional/WorkItemDetails/WorkItemHistory.jsx
@@ -22,7 +22,7 @@ export default React.createClass({
             collection.push(
                 <div className="history">
                     <div><a className="who" href={mailTo} dangerouslySetInnerHTML={highlight(entry.who)} /> <span className="when">{dateTime.fromNow()}</span></div>
-                    <div className="comment" dangerouslySetInnerHTML={highlight(entry.comment)}></div>
+                    <div className="comment" dangerouslySetInnerHTML={highlightHtml(entry.comment)}></div>
                 </div>
             );
         }

--- a/Elfie/Elfie.Test/Elfie.Test.csproj
+++ b/Elfie/Elfie.Test/Elfie.Test.csproj
@@ -88,6 +88,7 @@
     <Compile Include="SampleElfieStructure.V1.cs" />
     <Compile Include="SampleElfieStructure.cs" />
     <Compile Include="Serialization\BaseTabularTests.cs" />
+    <Compile Include="Serialization\IISLogReaderTests.cs" />
     <Compile Include="Serialization\ITabularValueTests.cs" />
     <Compile Include="Serialization\JsonTabularWriterTests.cs" />
     <Compile Include="Serialization\TsvWriterTests.cs" />

--- a/Elfie/Elfie.Test/Serialization/IISLogReaderTests.cs
+++ b/Elfie/Elfie.Test/Serialization/IISLogReaderTests.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.CodeAnalysis.Elfie.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.Elfie.Test.Serialization
+{
+    [TestClass]
+    public class IISLogReaderTests
+    {
+        private const string SampleContent = @"#Software: Microsoft Internet Information Services 8.5
+#Version: 1.0
+#Date: 2017-05-13 00:28:25
+#Fields: date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) sc-status sc-substatus sc-win32-status time-taken
+2017-05-13 00:28:25 10.10.1.1 GET /allBasics - 42785 - 10.10.1.2 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/52.0.2743.116+Safari/537.36+Edge/15.15063 https://arriba/ 401 2 5 453
+2017-05-13 00:28:26 10.10.1.1 GET /suggest q=Q1 42785 - 10.10.1.2 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/52.0.2743.116+Safari/537.36+Edge/15.15063 https://arriba/ 401 2 5 15
+2017-05-13 00:28:32 10.10.1.1 GET /suggest q=Q1 42785 DOMAIN\user1 10.10.1.2 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/52.0.2743.116+Safari/537.36+Edge/15.15063 https://arriba/ 200 0 0 5484
+2017-05-13 00:28:32 10.10.1.1 GET /allBasics - 42785 DOMAIN\user1 10.10.1.2 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/52.0.2743.116+Safari/537.36+Edge/15.15063 https://arriba/ 200 0 0 6437
+#Software: Microsoft Internet Information Services 8.5
+#Version: 1.0
+#Date: 2017-05-13 01:06:31
+#Fields: date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) sc-status sc-substatus sc-win32-status time-taken
+2017-05-13 01:06:30 10.10.1.1 GET /allBasics - 42785 - 10.10.1.3 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/52.0.2743.116+Safari/537.36+Edge/15.15063 https://arriba/ 401 2 5 406
+2017-05-13 01:06:38 10.10.1.1 GET /allBasics - 42785 DOMAIN\user2 10.10.1.3 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/52.0.2743.116+Safari/537.36+Edge/15.15063 https://arriba/ 200 0 0 6516
+#Software: Microsoft Internet Information Services 8.5
+#Version: 1.0
+#Date: 2017-05-13 02:46:47
+#Fields: date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) sc-status sc-substatus sc-win32-status time-taken
+2017-05-13 02:46:47 10.10.1.1 GET /allBasics - 42785 - 10.10.1.4 Mozilla/4.0+(compatible;+MSIE+7.0;+Windows+NT+10.0;+WOW64;+Trident/7.0;+Touch;+.NET4.0C;+.NET4.0E;+.NET+CLR+2.0.50727;+.NET+CLR+3.0.30729;+.NET+CLR+3.5.30729;+Tablet+PC+2.0;+InfoPath.3) https://arriba/ 401 2 5 968";
+
+        [TestMethod]
+        public void IISLogReader_Basics()
+        {
+            File.WriteAllText("Sample.iislog", SampleContent);
+
+            using (ITabularReader reader = new IISTabularReader("Sample.iislog"))
+            {
+                // Validate column names found
+                Assert.AreEqual("date, time, s-ip, cs-method, cs-uri-stem, cs-uri-query, s-port, cs-username, c-ip, cs(User-Agent), cs(Referer), sc-status, sc-substatus, sc-win32-status, time-taken", string.Join(", ", reader.Columns));
+
+                while (reader.NextRow())
+                {
+                    // Spot Check values
+                    Assert.AreEqual("2017-05-13", reader.Current(0).ToString());
+                    Assert.AreEqual("10.10.1.1", reader.Current(2).ToString());
+                    Assert.AreEqual("GET", reader.Current(3).ToString());
+                    Assert.AreEqual("https://arriba/", reader.Current(10).ToString());
+                }
+
+                // Validate row count read
+                Assert.AreEqual(7, reader.RowCountRead);
+            }
+        }
+    }
+}

--- a/Elfie/Elfie/Elfie.csproj
+++ b/Elfie/Elfie/Elfie.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Serialization\FileIO.cs" />
     <Compile Include="Serialization\IBinarySerializable.cs" />
     <Compile Include="Model\Columns\IColumn.cs" />
+    <Compile Include="Serialization\IISTabularReader.cs" />
     <Compile Include="Serialization\ITabularValue.cs" />
     <Compile Include="Serialization\ITabularReader.cs" />
     <Compile Include="Serialization\ITabularWriter.cs" />

--- a/Elfie/Elfie/Model/Strings/UTF8.cs
+++ b/Elfie/Elfie/Model/Strings/UTF8.cs
@@ -7,6 +7,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
     {
         public const byte Null = (byte)'\0';
         public const byte Quote = (byte)'"';
+        public const byte Pound = (byte)'#';
         public const byte Comma = (byte)',';
         public const byte Dash = (byte)'-';
         public const byte Period = (byte)'.';

--- a/Elfie/Elfie/Serialization/IISTabularReader.cs
+++ b/Elfie/Elfie/Serialization/IISTabularReader.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.CodeAnalysis.Elfie.Model.Strings;
+using Microsoft.CodeAnalysis.Elfie.Model.Structures;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.Elfie.Serialization
+{
+    /// <summary>
+    ///  IISTabularReader is a tabular reader for the IIS log format,
+    ///  which has '#' comment lines, newline-delimited rows, and space
+    ///  delimited values.
+    /// </summary>
+    public class IISTabularReader : BaseTabularReader
+    {
+        public IISTabularReader(string filePath) : base(filePath, false)
+        {
+            ReadColumns();
+        }
+
+        public IISTabularReader(Stream stream) : base(stream, false)
+        {
+            ReadColumns();
+        }
+
+        private bool IsCommentRow()
+        {
+            if (this.CurrentRowColumns == 0) return false;
+
+            String8 firstCell = this.Current(0).ToString8();
+            if (firstCell.IsEmpty()) return false;
+
+            return firstCell[0] == UTF8.Pound;
+        }
+
+        /// <summary>
+        ///  Read initial comment rows and find and log the column names from the first "#Fields:" row.
+        /// </summary>
+        private void ReadColumns()
+        {
+            while (base.NextRow())
+            {
+                this.RowCountRead--;
+
+                if (!IsCommentRow())
+                {
+                    throw new IOException("Reader couldn't find a #Fields: header in IIS Log.");
+                }
+
+                if (this.Current(0).ToString8().Equals("#Fields:"))
+                {
+                    for (int i = 1; i < this.CurrentRowColumns; ++i)
+                    {
+                        string columnName = this.Current(i).ToString();
+                        _columnHeadingsList.Add(columnName);
+                        _columnHeadings[columnName] = i - 1;
+                    }
+
+                    return;
+                }
+            }
+        }
+
+        public override bool NextRow()
+        {
+            // Read rows internally, skipping comment rows
+            while(base.NextRow())
+            {
+                if (!IsCommentRow()) return true;
+                this.RowCountRead--;
+            }
+
+            // If we reached EOF, return false
+            return false;
+        }
+
+        protected override String8Set SplitCells(String8 row, PartialArray<int> cellPositionArray)
+        {
+            // Remove trailing '\r' to handle '\r\n' and '\n' line endings uniformly
+            if (row.EndsWith(UTF8.CR)) row = row.Substring(0, row.Length - 1);
+
+            return row.Split(UTF8.Space, cellPositionArray);
+        }
+
+        protected override String8Set SplitRows(String8 block, PartialArray<int> rowPositionArray)
+        {
+            return block.Split(UTF8.Newline, rowPositionArray);
+        }
+    }
+}

--- a/Elfie/Elfie/Serialization/TabularFactory.cs
+++ b/Elfie/Elfie/Serialization/TabularFactory.cs
@@ -19,7 +19,10 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
             Writers = new Dictionary<string, Func<string, ITabularWriter>>(StringComparer.OrdinalIgnoreCase);
 
             Readers["csv"] = (path) => new CsvReader(path);
+            Readers["csvNH"] = (path) => new CsvReader(MapExtension(path, ".csv"), false);
             Readers["tsv"] = (path) => new TsvReader(path);
+            Readers["tsvNH"] = (path) => new TsvReader(MapExtension(path, ".tsv"), false);
+            Readers["iislog"] = (path) => new IISTabularReader(MapExtension(path, ".log"));
 
             Writers["cout"] = (path) => new ConsoleTabularWriter();
             Writers["csv"] = (path) => new CsvWriter(path, true);
@@ -52,6 +55,15 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
                     }
                 }
             }
+        }
+
+        private static string MapExtension(string filePath, string toExtension)
+        {
+            // If the file exists with that extension, leave it alone
+            if (File.Exists(filePath)) return filePath;
+
+            // Otherwise, change the extension
+            return Path.ChangeExtension(filePath, toExtension);
         }
 
         private static Func<string, T> GetStringConstructorFunc<T>(string keyName, string assemblyName, string typeName)

--- a/Elfie/Elfie/Serialization/TabularFactory.cs
+++ b/Elfie/Elfie/Serialization/TabularFactory.cs
@@ -110,5 +110,52 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
 
             throw new NotSupportedException(String.Format("Xsv does not know how to write \"{0}\". Known Extensions: [{1}]", extension, String.Join(", ", Writers.Keys)));
         }
+
+        public static ITabularWriter AppendWriter(string filePath, IEnumerable<string> columnNames)
+        {
+            ITabularWriter writer;
+
+            // If the file doesn't exist, make a new writer
+            if (!File.Exists(filePath))
+            {
+                writer = BuildWriter(filePath);
+                writer.SetColumns(columnNames);
+                return writer;
+            }
+
+            // Verify columns match
+            string expectedColumns = string.Join(", ", columnNames);
+
+            using (ITabularReader r = TabularFactory.BuildReader(filePath))
+            {
+                string actualColumns = string.Join(", ", r.Columns);
+                if (string.Compare(expectedColumns, actualColumns, true) != 0)
+                {
+                    throw new InvalidOperationException(string.Format("Can't append to \"{0}\" because the column names don't match.\r\nExpect: {1}\r\nActual: {2}", filePath, expectedColumns, actualColumns));
+                }
+            }
+
+            // Build the writer
+            FileStream s = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+
+            string extension = Path.GetExtension(filePath).ToLowerInvariant().TrimStart('.');
+            switch(extension)
+            {
+                case "csv":
+                    writer = new CsvWriter(s, false);
+                    break;
+                case "tsv":
+                    writer = new TsvWriter(s, false);
+                    break;
+                default:
+                    s.Dispose();
+                    throw new NotSupportedException(String.Format("Xsv does not know how to append to \"{0}\". Known Extensions: [csv, tsv]", extension));
+            }
+
+            // Set the columns so the writer knows the count (writers shouldn't write the columns if writeHeaderRow was false)
+            writer.SetColumns(columnNames);
+
+            return writer;
+        }
     }
 }


### PR DESCRIPTION
Enable reading and transformations to get IIS logs converted for ingestion into Arriba.
- Elfie: Add IISLogReader.
- Elfie: Use fake file extensions to provide hints for TabularReader construction. (csvNH means csv with no header row).
- Xsv: Add append mode (append a tabular file to another with matching columns)
- Xsv: Add concatenateColumn mode (join two column values with a delimiter)
- Xsv: Add rowId mode (add an ascending integer ID column)

Ryley ConfluxSearch Fixes:
- Grid accepts '[ColumnName]>' for expansions; factored easy methods to wrap and unwrap column names and values on QueryParser.
- 'highlight()' treats the content as non-HTML and ensures it's properly escaped.
- Added 'highlightHtml()' for HTML content. It still needs a sanitizer.
- Fix WorkItemHistory to interpret content as HTML.