### PR TITLE
Insights for Term Columns, Insights Fixes

### DIFF
--- a/Arriba/Arriba.Query/DistinctValueDimension.cs
+++ b/Arriba/Arriba.Query/DistinctValueDimension.cs
@@ -36,14 +36,14 @@ namespace Arriba.Model.Query
                         var dr = table.Query(new DistributionQuery(this.Column, "", true) { Where = where });
                         if (dr.Details.Succeeded && dr.Values != null)
                         {
-                            this.AddCondition(StringExtensions.Format("{0} <= {1}", QueryParser.WrapColumnName(this.Column), QueryParser.WrapValue(dr.Values[0, 0].ToString())));
+                            this.AddCondition(StringExtensions.Format("{0} <= {1}", QueryParser.WrapColumnName(this.Column), QueryParser.WrapValue(dr.Values[0, 0])));
 
                             for (var i = 1; i < dr.Values.RowCount - 1; i++)
                             {
-                                this.AddCondition(StringExtensions.Format("{0} <= {1} AND {0} > {2}", QueryParser.WrapColumnName(this.Column), QueryParser.WrapValue(dr.Values[i, 0].ToString()), QueryParser.WrapValue(dr.Values[i - 1, 0].ToString())));
+                                this.AddCondition(StringExtensions.Format("{0} <= {1} AND {0} > {2}", QueryParser.WrapColumnName(this.Column), QueryParser.WrapValue(dr.Values[i, 0]), QueryParser.WrapValue(dr.Values[i - 1, 0])));
                             }
 
-                            this.AddCondition(StringExtensions.Format("{0} > {1}", QueryParser.WrapColumnName(this.Column), QueryParser.WrapValue(dr.Values[dr.Values.RowCount - 2, 0].ToString())));
+                            this.AddCondition(StringExtensions.Format("{0} > {1}", QueryParser.WrapColumnName(this.Column), QueryParser.WrapValue(dr.Values[dr.Values.RowCount - 2, 0])));
 
                             return;
                         }
@@ -52,7 +52,7 @@ namespace Arriba.Model.Query
                     // Otherwise, use the Distinct values
                     for (var i = 0; i < result.Values.RowCount; i++)
                     {
-                        this.AddCondition(StringExtensions.Format("{0} = {1}", QueryParser.WrapColumnName(this.Column), QueryParser.WrapValue(result.Values[i, 0].ToString())));
+                        this.AddCondition(StringExtensions.Format("{0} = {1}", QueryParser.WrapColumnName(this.Column), QueryParser.WrapValue(result.Values[i, 0])));
                     }
                 }
             }

--- a/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
+++ b/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
@@ -24,6 +24,9 @@ namespace Arriba.Test.Model.Query
 
         public QueryIntelliSenseProviderTests()
         {
+            string[] names = new string[] { "University of North", "Northeasterly", "Southern University", "Southwestern", "Western State" };
+            string[] mascots = new string[] { "Unicorn", "Frog", "Marmot", "Elephant" };
+
             College = new Table();
             College.Name = "College";
             College.AddColumn(new ColumnDetails("ID", "int", -1) { IsPrimaryKey = true });
@@ -32,13 +35,14 @@ namespace Arriba.Test.Model.Query
             College.AddColumn(new ColumnDetails("SchoolYearLength", "TimeSpan", null));
             College.AddColumn(new ColumnDetails("SchoolHasMascot", "bool", null));
             College.AddColumn(new ColumnDetails("Student Count", "long", -1));
+            College.AddColumn(new ColumnDetails("Mascot", "string", null));
 
-            DataBlock items = new DataBlock(new string[] { "ID", "Name", "WhenFounded", "SchoolYearLength", "SchoolHasMascot", "Student Count" }, 100);
+            DataBlock items = new DataBlock(new string[] { "ID", "Name", "WhenFounded", "SchoolYearLength", "SchoolHasMascot", "Student Count", "Mascot" }, 100);
 
             for (int i = 0; i < 100; ++i)
             {
                 items[i, 0] = i;
-                items[i, 1] = i.ToString();
+                items[i, 1] = names[i % names.Length];
 
                 // School Age is 1/1/2017 minus up to 100k days
                 items[i, 2] = new DateTime(2017, 01, 01).AddDays(-1000 * i);
@@ -65,6 +69,8 @@ namespace Arriba.Test.Model.Query
                 }
 
                 items[i, 5] = studentCount;
+
+                items[i, 6] = mascots[i % mascots.Length];
             }
 
             College.AddOrUpdate(items);
@@ -134,7 +140,7 @@ namespace Arriba.Test.Model.Query
             Assert.AreEqual(0, result.Suggestions.Count);
 
             // No Query: ColumnNames, alphabetical, with no duplicates, then bare value, then TermPrefixes
-            string allColumnNamesOrTerm = "[Age], [City], [ID], [Name], [SchoolHasMascot], [SchoolYearLength], [Student Count], [WhenFounded], [*], !, (";
+            string allColumnNamesOrTerm = "[Age], [City], [ID], [Mascot], [Name], [SchoolHasMascot], [SchoolYearLength], [Student Count], [WhenFounded], [*], !, (";
             result = qi.GetIntelliSenseItems("", Tables);
             Assert.AreEqual(allColumnNamesOrTerm, string.Join(", ", result.Suggestions.Select(ii => ii.Display)));
             Assert.AreEqual("", result.SyntaxHint);
@@ -248,7 +254,7 @@ namespace Arriba.Test.Model.Query
             Assert.AreEqual(string.Join(", ", QueryIntelliSense.BooleanOperators.Select(ii => ii.Display)), string.Join(", ", result.Suggestions.Where(ii => ii.Category == QueryTokenCategory.BooleanOperator).Select(ii => ii.Display)));
 
             // "[Student Count] < 7000 &&" suggests column, value, term prefix
-            string collegeNamesOrTerm = "[ID], [Name], [SchoolHasMascot], [SchoolYearLength], [Student Count], [WhenFounded], [*], !, (";
+            string collegeNamesOrTerm = "[ID], [Mascot], [Name], [SchoolHasMascot], [SchoolYearLength], [Student Count], [WhenFounded], [*], !, (";
             result = qi.GetIntelliSenseItems("[Student Count] < 7000 &&", Tables);
             Assert.AreEqual(collegeNamesOrTerm, string.Join(", ", result.Suggestions.Select(ii => ii.Display)));
 
@@ -312,6 +318,26 @@ namespace Arriba.Test.Model.Query
             // Only provide type hint (and no error) for unsupported type
             result = qi.GetIntelliSenseItems("[ID] < 0 AND [Name] >= ", Tables);
             Assert.AreEqual(0, result.Suggestions.Count);
+
+            // Term column suggestions are offered
+            result = qi.GetIntelliSenseItems("Uni", Tables);
+            Assert.AreEqual("[Name] : Uni 73 %, [Mascot] : Uni 45 %", ItemsAndCounts(result));
+
+            // Term column suggestions are based on the remaining query rows
+            result = qi.GetIntelliSenseItems("[Mascot] : Uni AND Uni", Tables);
+            Assert.AreEqual("[Mascot] : Uni all, [Name] : Uni 40 %", ItemsAndCounts(result));
+
+            // Term suggestions only show for columns which have any matches
+            result = qi.GetIntelliSenseItems("Ele", Tables);
+            Assert.AreEqual("[Mascot] : Ele all", ItemsAndCounts(result));
+
+            // Term suggestions only show if the term has matches
+            result = qi.GetIntelliSenseItems("Elelion", Tables);
+            Assert.AreEqual("", ItemsAndCounts(result));
+
+            // Term suggestions only show if remaining terms have matches
+            result = qi.GetIntelliSenseItems("[ID] < 0 AND Uni", Tables);
+            Assert.AreEqual("", ItemsAndCounts(result));
         }
 
         private static string ItemsAndCounts(IntelliSenseResult result)

--- a/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
+++ b/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
@@ -27,7 +27,8 @@ namespace Arriba.Test.Model.Query
             string[] names = new string[] { "University of North", "Northeasterly", "Southern University", "Southwestern", "Western State" };
             string[] mascots = new string[] { "Unicorn", "Frog", "Marmot", "Elephant" };
 
-            College = new Table();
+            // Build a sample table with more than one partition (to verify merging)
+            College = new Table("College", 100000);
             College.Name = "College";
             College.AddColumn(new ColumnDetails("ID", "int", -1) { IsPrimaryKey = true });
             College.AddColumn(new ColumnDetails("Name", "string", null));
@@ -309,7 +310,7 @@ namespace Arriba.Test.Model.Query
 
             // Works for TimeSpan
             result = qi.GetIntelliSenseItems("[SchoolYearLength] >= ", Tables);
-            Assert.AreEqual("211.00:00:00 12 %, 207.00:00:00 24 %, 203.00:00:00 36 %, 199.00:00:00 48 %, 195.00:00:00 60 %, 191.00:00:00 76 %, 187.00:00:00 92 %", ItemsAndCounts(result));
+            Assert.AreEqual("211.00:00:00 12 %, 208.00:00:00 21 %, 204.00:00:00 33 %, 200.00:00:00 45 %, 196.00:00:00 57 %, 192.00:00:00 72 %, 188.00:00:00 88 %", ItemsAndCounts(result));
 
             // Works for DateTime
             result = qi.GetIntelliSenseItems("[WhenFounded] >= ", Tables);
@@ -509,7 +510,7 @@ namespace Arriba.Test.Model.Query
         public void PercentilesAndDistributions()
         {
             DataBlockResult pr = Tables[0].Query(new PercentilesQuery("SchoolYearLength", "", new double[] { 0.1, 0.5, 0.9 }));
-            Assert.AreEqual("187.00:00:00, 198.00:00:00, 211.00:00:00", string.Join(", ", (object[])pr.Values.GetColumn(1)));
+            Assert.AreEqual("188.00:00:00, 199.00:00:00, 211.00:00:00", string.Join(", ", (object[])pr.Values.GetColumn(1)));
 
             DataBlockResult dr = Tables[0].Query(new DistributionQuery("SchoolYearLength", "", true));
         }

--- a/Arriba/Arriba/Arriba.csproj
+++ b/Arriba/Arriba/Arriba.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Model\Column\IpRangeColumn.cs" />
     <Compile Include="Model\Query\DistributionQuery.cs" />
     <Compile Include="Model\Query\PercentilesQuery.cs" />
+    <Compile Include="Model\Query\TermInColumnsQuery.cs" />
     <Compile Include="Structures\IpRange.cs" />
     <Compile Include="Model\Correctors\ColumnSecurityCorrector.cs" />
     <Compile Include="Model\Correctors\JoinCorrector.cs" />

--- a/Arriba/Arriba/Model/Expressions/Expressions.cs
+++ b/Arriba/Arriba/Model/Expressions/Expressions.cs
@@ -279,7 +279,7 @@ namespace Arriba.Model.Expressions
 
         public override string ToString()
         {
-            return StringExtensions.Format("{0}{1}{2}", QueryParser.WrapColumnName(this.ColumnName), this.Operator.ToSyntaxString(), QueryParser.WrapValue(this.Value.ToString()));
+            return StringExtensions.Format("{0}{1}{2}", QueryParser.WrapColumnName(this.ColumnName), this.Operator.ToSyntaxString(), QueryParser.WrapValue(this.Value));
         }
     }
 
@@ -423,7 +423,7 @@ namespace Arriba.Model.Expressions
                     break;
                 }
 
-                result.Append(QueryParser.WrapValue(this.Values.GetValue(i).ToString()));
+                result.Append(QueryParser.WrapValue(this.Values.GetValue(i)));
             }
 
             result.Append(")");

--- a/Arriba/Arriba/Model/Query/DistinctQueryTop.cs
+++ b/Arriba/Arriba/Model/Query/DistinctQueryTop.cs
@@ -50,13 +50,13 @@ namespace Arriba.Model.Query
             // Capture the total of the base query
             result.Total = whereSet.Count();
 
-            // Add a prefix filter for the prefix so far, if any
-            if(!String.IsNullOrEmpty(this.ValuePrefix))
+            // Add a prefix filter for the prefix so far, if any and the column can prefix match
+            if (!String.IsNullOrEmpty(this.ValuePrefix))
             {
+                ExecutionDetails prefixDetails = new ExecutionDetails();
                 ShortSet prefixSet = new ShortSet(p.Count);
-                new TermExpression(this.Column, Operator.StartsWith, this.ValuePrefix).TryEvaluate(p, prefixSet, result.Details);
-
-                whereSet.And(prefixSet);
+                new TermExpression(this.Column, Operator.StartsWith, this.ValuePrefix).TryEvaluate(p, prefixSet, prefixDetails);
+                if (prefixDetails.Succeeded) whereSet.And(prefixSet);
             }
 
             if (result.Details.Succeeded)

--- a/Arriba/Arriba/Model/Query/DistinctQueryTop.cs
+++ b/Arriba/Arriba/Model/Query/DistinctQueryTop.cs
@@ -10,10 +10,8 @@ using Arriba.Structures;
 namespace Arriba.Model.Query
 {
     /// <summary>
-    ///  DistinctQuery enables getting the set of unique values for a given
-    ///  column within a specific filter up to a configured limit. It is
-    ///  roughly equivalent to SELECT DISTINCT [column] in SQL, but only for
-    ///  a single column.
+    ///  DistinctQueryTop returns the most common unique values for a given column
+    ///  in a given query. It is used to provide Inline Insight results for "[Column] = ".
     /// </summary>
     public class DistinctQueryTop : DistinctQuery
     {

--- a/Arriba/Arriba/Model/Query/DistributionQuery.cs
+++ b/Arriba/Arriba/Model/Query/DistributionQuery.cs
@@ -20,6 +20,7 @@ namespace Arriba.Model.Query
     {
         private Array Buckets { get; set; }
 
+        public int BucketCount { get; set; }
         public bool Inclusive { get; set; }
         public string Column { get; set; }
         public string TableName { get; set; }
@@ -27,13 +28,17 @@ namespace Arriba.Model.Query
         public bool RequireMerge => false;
 
         public DistributionQuery() : base()
-        { }
+        {
+            this.BucketCount = 7;
+        }
 
         public DistributionQuery(string columnName, string where, bool inclusive)
         {
             this.Column = columnName;
             this.Where = QueryParser.Parse(where);
             this.Inclusive = inclusive;
+
+            this.BucketCount = 7;
         }
 
         public void OnBeforeQuery(ITable table)
@@ -50,7 +55,7 @@ namespace Arriba.Model.Query
             {
                 // Try to choose buckets if the 10th and 90th percentile values were returned [returns null for unsupported types]
                 Bucketer bucketer = NativeContainer.CreateTypedInstance<Bucketer>(typeof(Bucketer<>), ((Table)table).GetColumnType(this.Column));
-                this.Buckets = bucketer.GetBuckets(result.Values);
+                this.Buckets = bucketer.GetBuckets(result.Values, this.Inclusive, this.BucketCount);
             }
         }
 
@@ -133,7 +138,7 @@ namespace Arriba.Model.Query
 
         internal abstract class Bucketer
         {
-            public abstract Array GetBuckets(DataBlock percentileResults);
+            public abstract Array GetBuckets(DataBlock percentileResults, bool inclusive, int bucketCount);
             public abstract DataBlock Bucket(IColumn column, ShortSet whereSet, Array buckets, bool inclusive);
         }
 
@@ -207,12 +212,14 @@ namespace Arriba.Model.Query
                 return result;
             }
 
-            public override Array GetBuckets(DataBlock percentileResults)
+            public override Array GetBuckets(DataBlock percentileResults, bool inclusive, int bucketCount)
             {
-                T[] buckets = new T[7];
+                T[] buckets = new T[bucketCount];
 
                 buckets[0] = (T)percentileResults[0, 1];
-                buckets[6] = (T)percentileResults[1, 1];
+                buckets[bucketCount - 1] = (T)percentileResults[percentileResults.RowCount - 1, 1];
+
+                if (buckets[0].Equals(buckets[bucketCount - 1])) return new T[1] { buckets[0] };
 
                 // Cast to a specific type at the array level to avoid per item casting
                 if (typeof(T).Equals(typeof(long)))

--- a/Arriba/Arriba/Model/Query/DistributionQuery.cs
+++ b/Arriba/Arriba/Model/Query/DistributionQuery.cs
@@ -3,13 +3,19 @@
 
 using System;
 
-using Arriba.Extensions;
 using Arriba.Model.Correctors;
 using Arriba.Model.Expressions;
 using Arriba.Structures;
 
 namespace Arriba.Model.Query
 {
+    /// <summary>
+    ///  DistributionQuery returns a distribution of values for a given column sampled from a given query.
+    ///  It creates equal-sized buckets between the 10th and 90th percentile values and returns
+    ///  the bucket boundary values and the count of items within each.
+    ///  
+    ///  It is used to provide Inline Insights for "[Column] > " for appropriate-typed columns.
+    /// </summary>
     public class DistributionQuery : IQuery<DataBlockResult>
     {
         private Array Buckets { get; set; }

--- a/Arriba/Arriba/Model/Query/QueryIntelliSense.cs
+++ b/Arriba/Arriba/Model/Query/QueryIntelliSense.cs
@@ -608,7 +608,7 @@ namespace Arriba.Model.Query
                 }
 
                 // Sort overall set by frequency descending
-                columnsForTerm.Sort((left, right) => right.Item2.CompareTo(left.Item2));
+                columnsForTerm.Sort((left, right) => ((double)right.Item2 / (double)right.Item3).CompareTo((double)left.Item2 / (double)left.Item3));
 
                 // Add top 10 suggestions
                 int countToReturn = Math.Min(10, columnsForTerm.Count);

--- a/Arriba/Arriba/Model/Query/QueryIntelliSense.cs
+++ b/Arriba/Arriba/Model/Query/QueryIntelliSense.cs
@@ -672,7 +672,7 @@ namespace Arriba.Model.Query
             if (count == total || total == 0) return "all";
 
             double percentage = (double)count / (double)total;
-            if (percentage < 0.1) return percentage.ToString("P1");
+            if (percentage < 0.01) return percentage.ToString("P1");
             return percentage.ToString("P0");
         }
 

--- a/Arriba/Arriba/Model/Query/QueryIntelliSense.cs
+++ b/Arriba/Arriba/Model/Query/QueryIntelliSense.cs
@@ -527,15 +527,15 @@ namespace Arriba.Model.Query
 
             for (int i = start; i != end; i += step)
             {
-                string value = topValues.Values[i, 0].ToString();
+                string value = QueryParser.WrapValue(topValues.Values[i, 0]);
                 int countForValue = (int)topValues.Values[i, 1];
                 if (isNotEquals) countForValue = (int)topValues.Total - countForValue;
                 double frequency = (double)countForValue / (double)(topValues.Total);
 
-                if ((countForValue > 1 || total <= 10) && value.StartsWith(guidance.Value, StringComparison.OrdinalIgnoreCase))
+                 if ((countForValue > 1 || total <= 10) && value.StartsWith(guidance.Value, StringComparison.OrdinalIgnoreCase))
                 {
                     string hint = (countForValue == topValues.Total ? "all" : frequency.ToString("P0"));
-                    suggestions.Add(new IntelliSenseItem(QueryTokenCategory.Value, QueryParser.WrapValue(value), hint));
+                    suggestions.Add(new IntelliSenseItem(QueryTokenCategory.Value, value, hint));
                 }
             }
         }
@@ -558,11 +558,11 @@ namespace Arriba.Model.Query
 
                 for (int i = distribution.Values.RowCount - 2; i >= 0; --i)
                 {
-                    string value = QueryParser.WrapValue(distribution.Values[i, 0].ToString());
+                    string value = QueryParser.WrapValue(distribution.Values[i, 0]);
                     double frequency = (double)countSoFar / (double)(distribution.Total);
                     int countForRange = (int)distribution.Values[i, 1];
 
-                    if ((int)distribution.Values[i + 1, 1] > 0 && value.StartsWith(guidance.Value, StringComparison.OrdinalIgnoreCase))
+                    if ((distribution.Values.RowCount == 2 || (int)distribution.Values[i + 1, 1] > 0) && value.StartsWith(guidance.Value, StringComparison.OrdinalIgnoreCase))
                     {
                         string hint = (countSoFar == (int)distribution.Total ? "all" : frequency.ToString("P0"));
                         suggestions.Add(new IntelliSenseItem(QueryTokenCategory.Value, value, hint));
@@ -577,13 +577,13 @@ namespace Arriba.Model.Query
 
                 for (int i = 0; i < distribution.Values.RowCount - 1; ++i)
                 {
-                    string value = QueryParser.WrapValue(distribution.Values[i, 0].ToString());
+                    string value = QueryParser.WrapValue(distribution.Values[i, 0]);
                     int countForRange = (int)distribution.Values[i, 1];
                     countSoFar += countForRange;
 
                     double frequency = (double)countSoFar / (double)(distribution.Total);
 
-                    if (countForRange > 0 && value.StartsWith(guidance.Value, StringComparison.OrdinalIgnoreCase))
+                    if ((distribution.Values.RowCount == 2 || countForRange > 0) && value.StartsWith(guidance.Value, StringComparison.OrdinalIgnoreCase))
                     {
                         string hint = (countSoFar == (int)distribution.Total ? "all" : frequency.ToString("P0"));
                         suggestions.Add(new IntelliSenseItem(QueryTokenCategory.Value, value, hint));
@@ -596,12 +596,12 @@ namespace Arriba.Model.Query
         {
             if (lastTerm != null && lastTerm.ColumnName == "*")
             {
-                string termValue = lastTerm.Value.ToString();
+                object termValue = lastTerm.Value;
                 List<Tuple<string, double>> columnsForTerm = new List<Tuple<string, double>>();
 
                 foreach (Table table in targetTables)
                 {
-                    DataBlockResult columns = table.Query(new TermInColumnsQuery(termValue, result.Query));
+                    DataBlockResult columns = table.Query(new TermInColumnsQuery(termValue.ToString(), result.Query));
                     for (int i = 0; i < columns.Values.RowCount; ++i)
                     {
                         double frequency = (double)(int)columns.Values[i, 1] / (double)columns.Total;

--- a/Arriba/Arriba/Model/Query/QueryParser.cs
+++ b/Arriba/Arriba/Model/Query/QueryParser.cs
@@ -57,14 +57,31 @@ namespace Arriba.Model.Query
         /// </summary>
         /// <param name="value">Value to wrap</param>
         /// <returns>Identifier version of value</returns>
-        public static string WrapValue(string value)
+        public static string WrapValue(object value)
         {
-            if (String.IsNullOrEmpty(value)) return "\"\"";
+            if (value == null) return "\"\"";
+
+            // Nicer DateTime formatting
+            if(value is DateTime)
+            {
+                DateTime dtv = (DateTime)value;
+                if(dtv.TimeOfDay.TotalSeconds == 0)
+                {
+                    value = dtv.ToString("yyyy-MM-dd");
+                }
+                else
+                {
+                    value = dtv.ToString("u");
+                }
+            }
+
+            string valueString = value.ToString();
+            if (valueString.Length == 0) return "\"\"";
 
             bool shouldEscape = false;
-            for (int i = 0; i < value.Length; ++i)
+            for (int i = 0; i < valueString.Length; ++i)
             {
-                char current = value[i];
+                char current = valueString[i];
                 if (Char.IsWhiteSpace(current) || current == '"')
                 {
                     shouldEscape = true;
@@ -72,9 +89,9 @@ namespace Arriba.Model.Query
                 }
             }
 
-            if (!shouldEscape) return value;
+            if (!shouldEscape) return valueString;
 
-            return StringExtensions.Format("\"{0}\"", value.Replace("\"", "\"\""));
+            return StringExtensions.Format("\"{0}\"", valueString.Replace("\"", "\"\""));
         }
 
         /// <summary>

--- a/Arriba/Arriba/Model/Query/TermInColumnsQuery.cs
+++ b/Arriba/Arriba/Model/Query/TermInColumnsQuery.cs
@@ -1,0 +1,134 @@
+﻿using System;
+
+using Arriba.Model.Correctors;
+using Arriba.Model.Expressions;
+using Arriba.Structures;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Arriba.Model.Query
+{
+    /// <summary>
+    ///  TermInColumnsQuery returns the set of columns in a given query which contain
+    ///  a specific bare term, in order by the count of rows with the term descending.
+    ///  
+    ///  It is used to provide Inline Insights for "BareTerm" queries.
+    /// </summary>
+    public class TermInColumnsQuery : IQuery<DataBlockResult>
+    {
+        public string Term { get; set; }
+
+        public string TableName { get; set; }
+        public IExpression Where { get; set; }
+        public bool RequireMerge => false;
+
+        public TermInColumnsQuery() : base()
+        { }
+
+        public TermInColumnsQuery(string term, string where)
+        {
+            this.Term = term;
+            this.Where = QueryParser.Parse(where);
+        }
+
+        public void OnBeforeQuery(ITable table)
+        { }
+
+        public void Correct(ICorrector corrector)
+        {
+            if (corrector == null) throw new ArgumentNullException("corrector");
+            this.Where = corrector.Correct(this.Where);
+        }
+
+        public DataBlockResult Compute(Partition p)
+        {
+            if (p == null) throw new ArgumentNullException("p");
+            DataBlockResult result = new DataBlockResult(this);
+
+            // Find matches for the remaining query
+            ShortSet baseQueryMatches = new ShortSet(p.Count);
+            this.Where.TryEvaluate(p, baseQueryMatches, result.Details);
+
+            // Find and count matches per column for the term in the outer query
+            List<Tuple<string, int>> matchCountPerColumn = new List<Tuple<string, int>>();
+
+            if (baseQueryMatches.Count() > 0)
+            {
+                TermExpression bareTerm = new TermExpression(this.Term);
+                ShortSet termMatchesForColumn = new ShortSet(p.Count);
+
+                foreach (IColumn<object> column in p.Columns.Values)
+                {
+                    termMatchesForColumn.Clear();
+                    column.TryWhere(Operator.Matches, this.Term, termMatchesForColumn, result.Details);
+                    termMatchesForColumn.And(baseQueryMatches);
+
+                    ushort matchCount = termMatchesForColumn.Count();
+                    if (matchCount > 0)
+                    {
+                        matchCountPerColumn.Add(new Tuple<string, int>(column.Name, (int)matchCount));
+                    }
+                }
+
+                // Sort results by count of matches descending
+                matchCountPerColumn.Sort((left, right) => right.Item2.CompareTo(left.Item2));
+            }
+
+            // Copy to a DataBlock and return it
+            int index = 0;
+            DataBlock block = new DataBlock(new string[] { "ColumnName", "Count" }, matchCountPerColumn.Count);
+            foreach(var column in matchCountPerColumn)
+            {
+                block[index, 0] = column.Item1;
+                block[index, 1] = column.Item2;
+                index++;
+            }
+
+            result.Values = block;
+            result.Total = baseQueryMatches.Count();
+            return result;
+        }
+
+        public DataBlockResult Merge(DataBlockResult[] partitionResults)
+        {
+            if (partitionResults == null) throw new ArgumentNullException("partitionResults");
+            if (partitionResults.Length == 0) throw new ArgumentException("Length==0 not supported", "partitionResults");
+            if (!partitionResults[0].Details.Succeeded) return partitionResults[0];
+
+            DataBlockResult mergedResult = new DataBlockResult(this);
+
+            // Add together the results per partition
+            Dictionary<string, int> matchCountPerColumn = new Dictionary<string, int>();
+            for(int partitionIndex = 0; partitionIndex < partitionResults.Length; ++partitionIndex)
+            {
+                DataBlockResult result = partitionResults[partitionIndex];
+
+                for(int rowIndex = 0; rowIndex < result.Values.RowCount; ++rowIndex)
+                {
+                    string columnName = (string)result.Values[rowIndex, 0];
+
+                    int count;
+                    matchCountPerColumn.TryGetValue(columnName, out count);
+
+                    matchCountPerColumn[columnName] = count + (int)result.Values[rowIndex, 1];
+                }
+
+                mergedResult.Details.Merge(result.Details);
+                mergedResult.Total += result.Total;
+            }
+
+            // Build a combined block sorted by count descending
+            DataBlock merged = new DataBlock(new string[] { "ColumnName", "Count" }, matchCountPerColumn.Count);
+            int index = 0;
+            foreach(var column in matchCountPerColumn.OrderByDescending((kvp) => kvp.Value))
+            {
+                merged[index, 0] = column.Key;
+                merged[index, 1] = column.Value;
+                index++;
+            }
+
+            mergedResult.Values = merged;
+            return mergedResult;
+        }
+    }
+}

--- a/Arriba/Arriba/Model/Query/TermInColumnsQuery.cs
+++ b/Arriba/Arriba/Model/Query/TermInColumnsQuery.cs
@@ -57,10 +57,17 @@ namespace Arriba.Model.Query
                 TermExpression bareTerm = new TermExpression(this.Term);
                 ShortSet termMatchesForColumn = new ShortSet(p.Count);
 
+                bool succeeded = false;
+                ExecutionDetails perColumnDetails = new ExecutionDetails();
+
                 foreach (IColumn<object> column in p.Columns.Values)
                 {
                     termMatchesForColumn.Clear();
-                    column.TryWhere(Operator.Matches, this.Term, termMatchesForColumn, result.Details);
+
+                    perColumnDetails.Succeeded = true;
+                    column.TryWhere(Operator.Matches, this.Term, termMatchesForColumn, perColumnDetails);
+                    succeeded |= perColumnDetails.Succeeded;
+
                     termMatchesForColumn.And(baseQueryMatches);
 
                     ushort matchCount = termMatchesForColumn.Count();


### PR DESCRIPTION
- Add Inline Insights to tell you which columns terms are from.
- Format DateTimes in insights more nicely; show only Date part if no Time.
- Value Insights now filters on column STARTSWITH prefix to keep showing values as you type.
- Distribution insights shows the value when there's only one (all MinValue/MaxValue)