### PR TITLE
Arriba: Better dynamic column add.

### DIFF
--- a/Arriba/Arriba.Test/Model/TableTests.cs
+++ b/Arriba/Arriba.Test/Model/TableTests.cs
@@ -238,18 +238,24 @@ namespace Arriba.Test.Model
             // Verify add didn't partially happen
             Assert.AreEqual(5, (int)t.Count);
 
-            // Build more data and a new column
-            DataBlock newData = new DataBlock(new string[] { "ID", "Resolution" }, 2,
+            // Add more data with existing and new columns
+            DataBlock newData = new DataBlock(new string[] { "ID", "Stack Rank", "Original Estimate", "Remaining Cost", "Actual Cost" }, 2,
                 new Array[]
                 {
-                    new int[] { 12345, 12346 },
-                    new string[] { "Fixed", "Won't Fix" }
+                    new int[] { 12345, 12346 },   // ID already exists
+                    new ushort[] { 1119, 1120 },  // Stack Rank type can be found from the typed array
+                    new object[] { 0, 0 },        // Original Estimate has no non-default values and shouldn't be added
+                    new object[] { 12, 0.5, 0 },  // Remaining Cost should be inferred to be float
+                    new float[] { 0, 0, 0 }       // Actual Cost is typed but with no non-default values and shouldn't be added
                 });
 
             // Verify AddOrUpdate with option set will add the new column
             t.AddOrUpdate(newData, new AddOrUpdateOptions() { AddMissingColumns = true });
 
-            Assert.AreEqual(7, (int)t.Count);
+            Assert.AreEqual("UInt16", t.GetDetails("Stack Rank").Type);
+            Assert.AreEqual("Single", t.GetDetails("Remaining Cost").Type);
+            Assert.IsNull(t.ColumnDetails.FirstOrDefault((cd) => cd.Name == "Original Estimate"));
+            Assert.IsNull(t.ColumnDetails.FirstOrDefault((cd) => cd.Name == "Actual Cost"));
         }
 
         [TestMethod]

--- a/Arriba/Arriba.Test/Structures/ValueTests.cs
+++ b/Arriba/Arriba.Test/Structures/ValueTests.cs
@@ -301,11 +301,11 @@ namespace Arriba.Test.Structures
             Assert.AreEqual("Int64", Value.Create(long.MaxValue).BestType(typeof(int)).Name);
             Assert.AreEqual("Int64", Value.Create(new ValueTypeReference<long>(long.MaxValue)).BestType(typeof(int)).Name);
 
-            // Floating point and integer turn into string
-            Assert.AreEqual("String", Value.Create(float.MaxValue).BestType(typeof(int)).Name);
-            Assert.AreEqual("String", Value.Create(new ValueTypeReference<float>(float.MaxValue)).BestType(typeof(int)).Name);
-            Assert.AreEqual("String", Value.Create(double.MaxValue).BestType(typeof(long)).Name);
-            Assert.AreEqual("String", Value.Create(new ValueTypeReference<double>(double.MaxValue)).BestType(typeof(long)).Name);
+            // Floating point and integer turn into float
+            Assert.AreEqual("Single", Value.Create(float.MaxValue).BestType(typeof(int)).Name);
+            Assert.AreEqual("Single", Value.Create(new ValueTypeReference<float>(float.MaxValue)).BestType(typeof(int)).Name);
+            Assert.AreEqual("Double", Value.Create(double.MaxValue).BestType(typeof(long)).Name);
+            Assert.AreEqual("Double", Value.Create(new ValueTypeReference<double>(double.MaxValue)).BestType(typeof(long)).Name);
 
             // Other combinations turn into string
             Assert.AreEqual("String", Value.Create(Guid.NewGuid()).BestType(typeof(long)).Name);

--- a/Arriba/Arriba/Model/Column/ColumnFactory.cs
+++ b/Arriba/Arriba/Model/Column/ColumnFactory.cs
@@ -92,6 +92,106 @@ namespace Arriba
             return new FastAddSortedColumn<T>(column, initialCapacity);
         }
 
+        public static Type GetTypeFromTypeString(string columnDetailsType)
+        {
+            if (String.IsNullOrEmpty(columnDetailsType)) return null;
+
+            switch(columnDetailsType.ToLowerInvariant())
+            {
+                case "bool":
+                case "boolean":
+                    return typeof(bool);
+                case "byte":
+                    return typeof(byte);
+                case "short":
+                case "int16":
+                    return typeof(short);
+                case "int":
+                case "int32":
+                    return typeof(int);
+                case "long":
+                case "int64":
+                    return typeof(long);
+                case "float":
+                case "single":
+                    return typeof(float);
+                case "double":
+                    return typeof(double);
+                case "ushort":
+                case "uint16":
+                    return typeof(ushort);
+                case "uint":
+                case "uint32":
+                    return typeof(uint);
+                case "ulong":
+                case "uint64":
+                    return typeof(ulong);
+                case "datetime":
+                    return typeof(DateTime);
+                case "guid":
+                    return typeof(Guid);
+                case "timespan":
+                    return typeof(TimeSpan);
+                case "string":
+                case "json":
+                case "html":
+                case "stringset":
+                    return typeof(string);
+                default:
+                    return null;
+            }
+        }
+
+        public static object GetDefaultValueFromTypeString(string columnDetailsType)
+        {
+            if (String.IsNullOrEmpty(columnDetailsType)) return null;
+
+            switch (columnDetailsType.ToLowerInvariant())
+            {
+                case "bool":
+                case "boolean":
+                    return default(bool);
+                case "byte":
+                    return default(byte);
+                case "short":
+                case "int16":
+                    return default(short);
+                case "int":
+                case "int32":
+                    return default(int);
+                case "long":
+                case "int64":
+                    return default(long);
+                case "float":
+                case "single":
+                    return default(float);
+                case "double":
+                    return default(double);
+                case "ushort":
+                case "uint16":
+                    return default(ushort);
+                case "uint":
+                case "uint32":
+                    return default(uint);
+                case "ulong":
+                case "uint64":
+                    return default(ulong);
+                case "datetime":
+                    return default(DateTime);
+                case "guid":
+                    return default(Guid);
+                case "timespan":
+                    return default(TimeSpan);
+                case "string":
+                case "json":
+                case "html":
+                case "stringset":
+                    return default(string);
+                default:
+                    return null;
+            }
+        }
+
         /// <summary>
         ///  Construct a column given a TypeDescriptor. The column contains the base type
         ///  and may be wrapped in other columns which add additional functionality

--- a/Arriba/Arriba/Model/Partition.cs
+++ b/Arriba/Arriba/Model/Partition.cs
@@ -235,10 +235,14 @@ namespace Arriba.Model
                 if (column.Count != newCount) column.SetSize(newCount);
             }
 
-            // Set values for each other provided column
+            // Set values for each other provided column which exists
+            //  Columns which don't exist at this point were omitted because they had no non-default values
             for (int columnIndex = 0; columnIndex < columnCount; ++columnIndex)
             {
-                FillPartitionColumn(values, columnIndex, itemLIDs);
+                if (this.ContainsColumn(values.Columns[columnIndex].Name))
+                {
+                    FillPartitionColumn(values, columnIndex, itemLIDs);
+                }
             }
 
             // Commit every column [ones with new values and ones resized with defaults]

--- a/Arriba/Arriba/Model/Table.cs
+++ b/Arriba/Arriba/Model/Table.cs
@@ -330,20 +330,14 @@ namespace Arriba.Model
             List<ColumnDetails> columnsToAdd = new List<ColumnDetails>();
 
             // Find the ID column
-            ColumnDetails idColumn = _partitions[0].IDColumn;
-
-            // Does the DataBlock specify the ID column?
-            idColumn = idColumn ?? values.Columns.FirstOrDefault((cd) => cd.IsPrimaryKey);
-
-            // If not, does one end with 'ID'?
-            idColumn = idColumn ?? values.Columns.FirstOrDefault((cd) => cd.Name.EndsWith("ID"));
-
-            // If not, use the first column
-            idColumn = idColumn ?? values.Columns.FirstOrDefault();
+            //  [The existing one, or one marked as primary key on the block, or one ending with 'ID', or the first column]
+            ColumnDetails idColumn = _partitions[0].IDColumn
+                ?? values.Columns.FirstOrDefault((cd) => cd.IsPrimaryKey)
+                ?? values.Columns.FirstOrDefault((cd) => cd.Name.EndsWith("ID"))
+                ?? values.Columns.FirstOrDefault();
 
             // Mark the ID column
             idColumn.IsPrimaryKey = true;
-
 
             for (int columnIndex = 0; columnIndex < values.ColumnCount; ++columnIndex)
             {

--- a/Arriba/Arriba/Structures/Value.cs
+++ b/Arriba/Arriba/Structures/Value.cs
@@ -391,6 +391,10 @@ namespace Arriba.Structures
         /// <returns>Best type fitting both bestSoFar and this value</returns>
         public Type BestType(Type bestSoFar)
         {
+            // If there's an existing best and this value converts to it, keep it
+            object unused;
+            if (bestSoFar != null && TryConvert(bestSoFar, out unused)) return bestSoFar;
+
             Type thisBest = this.BestType();
 
             // If this is object, stick with bestSoFar
@@ -405,17 +409,36 @@ namespace Arriba.Structures
             // If either is string, it must be string
             if (thisBest.Equals(typeof(string)) || bestSoFar.Equals(typeof(string))) return typeof(string);
 
-            // If one int and one long, return long
-            if (bestSoFar.Equals(typeof(long)) && thisBest.Equals(typeof(int))) return typeof(long);
-            if (bestSoFar.Equals(typeof(int)) && thisBest.Equals(typeof(long))) return typeof(long);
-
-            // If one int and one double, return double
-            if (bestSoFar.Equals(typeof(double)) && thisBest.Equals(typeof(float))) return typeof(double);
-            if (bestSoFar.Equals(typeof(float)) && thisBest.Equals(typeof(double))) return typeof(double);
-
-            // If one int and one TimeSpan, settle on TimeSpan
-            if (bestSoFar.Equals(typeof(int)) && thisBest.Equals(typeof(TimeSpan))) return typeof(TimeSpan);
-            if (bestSoFar.Equals(typeof(TimeSpan)) && thisBest.Equals(typeof(int))) return typeof(TimeSpan);
+            // Allow converting to 'broader' types (int -> long, float -> double, int -> float)
+            if(bestSoFar.Equals(typeof(long)))
+            {
+                if (thisBest.Equals(typeof(int))) return typeof(long);
+                if (thisBest.Equals(typeof(float))) return typeof(float);
+                if (thisBest.Equals(typeof(double))) return typeof(double);
+            }
+            else if(bestSoFar.Equals(typeof(int)))
+            {
+                if (thisBest.Equals(typeof(long))) return typeof(long);
+                if (thisBest.Equals(typeof(float))) return typeof(float);
+                if (thisBest.Equals(typeof(double))) return typeof(double);
+                if (thisBest.Equals(typeof(int))) return typeof(TimeSpan);
+            }
+            else if (bestSoFar.Equals(typeof(float)))
+            {
+                if (thisBest.Equals(typeof(int))) return typeof(float);
+                if (thisBest.Equals(typeof(long))) return typeof(float);
+                if (thisBest.Equals(typeof(double))) return typeof(double);
+            }
+            else if(bestSoFar.Equals(typeof(double)))
+            {
+                if (thisBest.Equals(typeof(int))) return typeof(double);
+                if (thisBest.Equals(typeof(long))) return typeof(double);
+                if (thisBest.Equals(typeof(float))) return typeof(double);
+            }
+            else if(bestSoFar.Equals(typeof(TimeSpan)))
+            {
+                if (thisBest.Equals(typeof(int))) return typeof(TimeSpan);
+            }
 
             // Otherwise, must fall back to string
             return typeof(string);

--- a/Arriba/Arriba/Structures/Value.cs
+++ b/Arriba/Arriba/Structures/Value.cs
@@ -421,7 +421,8 @@ namespace Arriba.Structures
                 if (thisBest.Equals(typeof(long))) return typeof(long);
                 if (thisBest.Equals(typeof(float))) return typeof(float);
                 if (thisBest.Equals(typeof(double))) return typeof(double);
-                if (thisBest.Equals(typeof(int))) return typeof(TimeSpan);
+
+                if (thisBest.Equals(typeof(TimeSpan))) return typeof(TimeSpan);
             }
             else if (bestSoFar.Equals(typeof(float)))
             {

--- a/Arriba/Tools/Arriba.TfsWorkItemCrawler/ItemConsumers/ArribaDirectIndexerItemConsumer.cs
+++ b/Arriba/Tools/Arriba.TfsWorkItemCrawler/ItemConsumers/ArribaDirectIndexerItemConsumer.cs
@@ -50,11 +50,7 @@ namespace Arriba.TfsWorkItemCrawler.ItemConsumers
                 this.Table.Load(this.Configuration.ArribaTable);
             }
 
-            // Verify all columns match requested types [will throw if column exists but as different type]
-            foreach (ColumnDetails cd in columns)
-            {
-                this.Table.AddColumn(cd);
-            }
+            // Columns are added dynamically by Append
 
             // Set the table security
             SecureDatabase sdb = new SecureDatabase();
@@ -91,7 +87,7 @@ namespace Arriba.TfsWorkItemCrawler.ItemConsumers
             //    if (items[0, 0].ToString().Equals("721458")) Debugger.Break();
             //}
 
-            this.Table.AddOrUpdate(items);
+            this.Table.AddOrUpdate(items, new AddOrUpdateOptions() { AddMissingColumns = true });
 
             // REPRO: Identify the items causing consistency problems as we go. Too slow for full scale.
             //if (this.DiagnosticsEnabled && Debugger.IsAttached)


### PR DESCRIPTION
 - Only add columns when non-default values are first seen.
 - Use DataBlock ColumnDetails to tell types, if provided.
 - Use DataBlock array types to tell types, if strongly typed.
 - Add ColumnFactory type from type name and default from type name.
 - Value: Convert integer and floating point to floating point rather than string.

Arriba.TfsWorkItemCrawler:
 - Don't pre-add columns (so they'll be added as needed)
 - Pass ColumnDetails with types in DataBlocks for AddOrUpdate.