### PR TITLE
Lazy Column Creation fixes

### DIFF
--- a/Arriba/Arriba.Test/Model/TableTests.cs
+++ b/Arriba/Arriba.Test/Model/TableTests.cs
@@ -239,14 +239,17 @@ namespace Arriba.Test.Model
             Assert.AreEqual(5, (int)t.Count);
 
             // Add more data with existing and new columns
-            DataBlock newData = new DataBlock(new string[] { "ID", "Stack Rank", "Original Estimate", "Remaining Cost", "Actual Cost" }, 2,
+            DataBlock newData = new DataBlock(new string[] { "ID", "Stack Rank", "Original Estimate", "Remaining Cost", "Actual Cost", "Tertiary Owner", "When Imported" }, 2,
                 new Array[]
                 {
-                    new int[] { 12345, 12346 },   // ID already exists
-                    new ushort[] { 1119, 1120 },  // Stack Rank type can be found from the typed array
-                    new object[] { 0, 0 },        // Original Estimate has no non-default values and shouldn't be added
-                    new object[] { 12, 0.5, 0 },  // Remaining Cost should be inferred to be float
-                    new float[] { 0, 0, 0 }       // Actual Cost is typed but with no non-default values and shouldn't be added
+                    new int[] { 12345, 12346, 12347 },   // [ID] already exists
+                    new ushort[] { 1119, 1120, 1121 },   // [Stack Rank] type can be found from the typed array
+                    new object[] { 0, 0, 0 },            // [Original Estimate] has no non-default values and shouldn't be added
+                    new object[] { 12, 0.5, 0 },         // [Remaining Cost] should be inferred to be float
+                    new float[] { 0, 0, 0 },             // [Actual Cost] is typed but with no non-default values and shouldn't be added
+                    new object[] { "", "", null },       // [Tertiary Owner] has no non-default values (both null and "") and shouldn't be added
+                    new object[] { DateTime.MinValue, DateTime.MinValue.ToUniversalTime(), null} // [When Imported] has no non-default values (MinValue, MinValueUtc, null) and shouldn't be added
+
                 });
 
             // Verify AddOrUpdate with option set will add the new column
@@ -256,6 +259,8 @@ namespace Arriba.Test.Model
             Assert.AreEqual("Single", t.GetDetails("Remaining Cost").Type);
             Assert.IsNull(t.ColumnDetails.FirstOrDefault((cd) => cd.Name == "Original Estimate"));
             Assert.IsNull(t.ColumnDetails.FirstOrDefault((cd) => cd.Name == "Actual Cost"));
+            Assert.IsNull(t.ColumnDetails.FirstOrDefault((cd) => cd.Name == "Tertiary Owner"));
+            Assert.IsNull(t.ColumnDetails.FirstOrDefault((cd) => cd.Name == "When Imported"));
         }
 
         [TestMethod]

--- a/Arriba/Arriba.Test/Model/TableTests.cs
+++ b/Arriba/Arriba.Test/Model/TableTests.cs
@@ -239,16 +239,17 @@ namespace Arriba.Test.Model
             Assert.AreEqual(5, (int)t.Count);
 
             // Add more data with existing and new columns
-            DataBlock newData = new DataBlock(new string[] { "ID", "Stack Rank", "Original Estimate", "Remaining Cost", "Actual Cost", "Tertiary Owner", "When Imported" }, 2,
+            DataBlock newData = new DataBlock(new string[] { "ID", "Stack Rank", "Original Estimate", "Remaining Cost", "Wrapped Cost", "Actual Cost", "Tertiary Owner", "When Imported" }, 2,
                 new Array[]
                 {
-                    new int[] { 12345, 12346, 12347 },   // [ID] already exists
-                    new ushort[] { 1119, 1120, 1121 },   // [Stack Rank] type can be found from the typed array
-                    new object[] { 0, 0, 0 },            // [Original Estimate] has no non-default values and shouldn't be added
-                    new object[] { 12, 0.5, 0 },         // [Remaining Cost] should be inferred to be float
-                    new float[] { 0, 0, 0 },             // [Actual Cost] is typed but with no non-default values and shouldn't be added
-                    new object[] { "", "", null },       // [Tertiary Owner] has no non-default values (both null and "") and shouldn't be added
-                    new object[] { DateTime.MinValue, DateTime.MinValue.ToUniversalTime(), null} // [When Imported] has no non-default values (MinValue, MinValueUtc, null) and shouldn't be added
+                    new int[] { 12345, 12346, 12347 },                                              // [ID] already exists
+                    new ushort[] { 1119, 1120, 1121 },                                              // [Stack Rank] type can be found from the typed array
+                    new object[] { 0, 0, 0 },                                                       // [Original Estimate] has no non-default values and shouldn't be added
+                    new object[] { 12, 0.5, 0 },                                                    // [Remaining Cost] should be inferred to be float
+                    new Value[] { Value.Create(12), Value.Create(0.5), Value.Create(0) },           // [Wrapped Cost] should be unwrapped and inferred to be float
+                    new float[] { 0, 0, 0 },                                                        // [Actual Cost] is typed but with no non-default values and shouldn't be added
+                    new object[] { "", "", null },                                                  // [Tertiary Owner] has no non-default values (both null and "") and shouldn't be added
+                    new object[] { DateTime.MinValue, DateTime.MinValue.ToUniversalTime(), null}    // [When Imported] has no non-default values (MinValue, MinValueUtc, null) and shouldn't be added
 
                 });
 
@@ -257,6 +258,7 @@ namespace Arriba.Test.Model
 
             Assert.AreEqual("UInt16", t.GetDetails("Stack Rank").Type);
             Assert.AreEqual("Single", t.GetDetails("Remaining Cost").Type);
+            Assert.AreEqual("Single", t.GetDetails("Wrapped Cost").Type);
             Assert.IsNull(t.ColumnDetails.FirstOrDefault((cd) => cd.Name == "Original Estimate"));
             Assert.IsNull(t.ColumnDetails.FirstOrDefault((cd) => cd.Name == "Actual Cost"));
             Assert.IsNull(t.ColumnDetails.FirstOrDefault((cd) => cd.Name == "Tertiary Owner"));

--- a/Arriba/Arriba/Model/Table.cs
+++ b/Arriba/Arriba/Model/Table.cs
@@ -393,7 +393,10 @@ namespace Arriba.Model
                 }
 
                 // Set the column type
-                details.Type = details.Type ?? (inferredType ?? typeof(string)).Name;
+                if (String.IsNullOrEmpty(details.Type) || details.Type.Equals("Unknown"))
+                {
+                    details.Type = (determinedType ?? inferredType ?? typeof(string)).Name;
+                }
 
                 // Add the column if it had any non-default values (and didn't already exist)
                 if (hasNonDefaultValues) columnsToAdd.Add(details);

--- a/Arriba/Arriba/Model/Table.cs
+++ b/Arriba/Arriba/Model/Table.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -363,6 +362,7 @@ namespace Arriba.Model
 
                 Type inferredType = null;
                 Value v = Value.Create(details.Default);
+                DateTime defaultUtc = default(DateTime).ToUniversalTime();
 
                 for (int rowIndex = 0; rowIndex < values.RowCount; ++rowIndex)
                 {
@@ -383,9 +383,12 @@ namespace Arriba.Model
                     }
 
                     // Track whether any non-default values were seen
-                    if (hasNonDefaultValues == false && value != null)
+                    if (hasNonDefaultValues == false && value != null && !"".Equals(value) && !defaultUtc.Equals(value))
                     {
-                        if (columnDefault == null || columnDefault.Equals(value) == false) hasNonDefaultValues = true;
+                        if (columnDefault == null || columnDefault.Equals(value) == false)
+                        {
+                            hasNonDefaultValues = true;
+                        }
                     }
                 }
 

--- a/Arriba/Arriba/Model/Table.cs
+++ b/Arriba/Arriba/Model/Table.cs
@@ -330,20 +330,14 @@ namespace Arriba.Model
             List<ColumnDetails> columnsToAdd = new List<ColumnDetails>();
 
             // Find the ID column
-            ColumnDetails idColumn = _partitions[0].IDColumn;
-
-            // Does the DataBlock specify the ID column?
-            idColumn = idColumn ?? values.Columns.FirstOrDefault((cd) => cd.IsPrimaryKey);
-
-            // If not, does one end with 'ID'?
-            idColumn = idColumn ?? values.Columns.FirstOrDefault((cd) => cd.Name.EndsWith("ID"));
-
-            // If not, use the first column
-            idColumn = idColumn ?? values.Columns.FirstOrDefault();
+            //  [The existing one, or one marked as primary key on the block, or one ending with 'ID', or the first column]
+            ColumnDetails idColumn = _partitions[0].IDColumn
+                ?? values.Columns.FirstOrDefault((cd) => cd.IsPrimaryKey)
+                ?? values.Columns.FirstOrDefault((cd) => cd.Name.EndsWith("ID"))
+                ?? values.Columns.FirstOrDefault();
 
             // Mark the ID column
             idColumn.IsPrimaryKey = true;
-
 
             for (int columnIndex = 0; columnIndex < values.ColumnCount; ++columnIndex)
             {

--- a/Arriba/Arriba/Model/Table.cs
+++ b/Arriba/Arriba/Model/Table.cs
@@ -351,7 +351,7 @@ namespace Arriba.Model
 
                 // If not, is the DataBlock column array typed?
                 determinedType = determinedType ?? values.GetTypeForColumn(columnIndex);
-                if (determinedType == typeof(object)) determinedType = null;
+                if (determinedType == typeof(object) || determinedType == typeof(Value)) determinedType = null;
 
                 // Get the column default, if provided, or the default for the type, if provided
                 object columnDefault = details.Default;

--- a/Arriba/Arriba/Structures/Value.cs
+++ b/Arriba/Arriba/Structures/Value.cs
@@ -280,6 +280,8 @@ namespace Arriba.Structures
                 return null;
             }
 
+            if (String.IsNullOrEmpty(asString)) return asString;
+
             // If gotten, try parsing conversions to other types
             DateTime asDateTime = default(DateTime);
             Guid asGuid = default(Guid);


### PR DESCRIPTION
- Enable lazy column creation for DataBlock and JSON upload as well as CSV.
- Make lazy column creation work properly for 'Value' wrapped columns (parsed requests).
- Respect custom subtypes ("html") when designated on ColumnDetails.
- Fix issue defaulting to "unknown" as the type.
- Correctly recognize default values when Value wrapped