### PR TITLE
Arriba Usability fixes

### DIFF
--- a/Arriba/Arriba.Web/configuration.default/theme.scss
+++ b/Arriba/Arriba.Web/configuration.default/theme.scss
@@ -1,23 +1,27 @@
 // Palette URL: http://paletton.com/#uid=40z0u0ktLvaiqDmnzwTvIoQAEjB
 
+// Teal Theme
 $vdark  :hsl(191, 96%, 19%);
 $dark   :hsl(191, 92%, 25%);
 $medium :hsl(191, 82%, 33%);
 $light  :hsl(191, 56%, 41%);
 $vlight :hsl(191, 41%, 52%);
 
+// // Orange Theme
 // $vdark  :hsl(30, 100%, 31%);
 // $dark   :hsl(30, 98%,  39%);
 // $medium :hsl(30, 94%,  52%);
 // $light  :hsl(30, 100%, 63%);
 // $vlight :hsl(30, 100%, 71%);
 
+// // Green Theme
 // $vdark  :hsl(136, 100%, 23%);
 // $dark   :hsl(136, 99%,  29%);
 // $medium :hsl(136, 87%,  39%);
 // $light  :hsl(136, 58%,  48%);
 // $vlight :hsl(136, 55%,  58%);
 
+// // Blue Theme
 // $vdark  :hsl(227, 83%, 23%);
 // $dark   :hsl(227, 77%, 30%);
 // $medium :hsl(227, 70%, 39%);

--- a/Arriba/Configuration/SetArribaACLs.cmd
+++ b/Arriba/Configuration/SetArribaACLs.cmd
@@ -1,12 +1,15 @@
 @ECHO OFF
 PUSHD %~dp0..
+SET ServiceAccount=%1
 
-:: The Arriba service runs as an App Pool account, which has read/execute access to the Arriba site, DiskCache, and read-write access to the Arriba Logs.
-:: Users browsing access the site as themselves (Windows Auth). Everyone needs read/execute access to the Arriba.Web and redirect site only.
+:: The Arriba service runs as an App Pool account, which needs read-write access to DiskCache and Logs.
+:: Users access the site as themselves, due to Windows Authentication, so Everyone needs read/execute access to Arriba.IIS, Arriba.Web, and Redirect.
+:: If Tables are written directly only (not imported to the Arriba HTTP service), the DiskCache folder can be read only for IIS_IUSRS for extra security.
 
 ECHO - DiskCache [Arriba Data]
 IF NOT EXIST DiskCache (MD DiskCache)
-ICACLS DiskCache /Grant IIS_IUSRS:(OI)(CI)(RX)
+ICACLS DiskCache /Grant IIS_IUSRS:(OI)(CI)(F)
+IF NOT "%1"=="" ICACLS DiskCache /Grant %1:(OI)(CI)(F)
 ICACLS DiskCache\* /Reset /T
 
 ECHO - Arriba.IIS

--- a/Arriba/Databases/Louvau/Configuration/Configuration.jsx
+++ b/Arriba/Databases/Louvau/Configuration/Configuration.jsx
@@ -8,9 +8,6 @@
         // Name of tool to show [top right and elsewhere]
         toolName: "Bung",
 
-        // Theme to use [see theme.css for options and to define others]
-        theme: "theme-teal",
-
         // E-Mail addresses to whom feedback should go
         feedbackEmailAddresses: "slouvau@hotmail.com",
 
@@ -27,7 +24,7 @@
         databaseName : "Louvau",
         directLinkUrl : "https://scottlo.visualstudio.com/Louvau/_workitems/edit/",
 
-        // Grid: Pre-defined Grid queries
+        // Grid: Pre-defined Grid queries which appear in the 'Load' dropdown in the Grid view
         /* gridDefault: "<NameOfDefaultPredefinedQuery>", */
         gridDefaultQueries: {
             "Clear": {},

--- a/Arriba/Databases/Walkthrough/Configuration/Configuration.jsx
+++ b/Arriba/Databases/Walkthrough/Configuration/Configuration.jsx
@@ -8,9 +8,6 @@
         // Name of tool to show [top right and elsewhere]
         toolName: "Rates",
 
-        // Theme to use [see theme.css for options and to define others]
-        theme: "theme-orange",
-
         // E-Mail addresses to whom feedback should go
         feedbackEmailAddresses: "",
 


### PR DESCRIPTION
- Build.js improvements (require a path, copy back to previous config folder, validate first).
- Arriba.Csv /setCreators to allow configuring create table identities.
- SetArribaACLS.cmd can take a crawler account and sets IIS_IUSRS write access to DiskCache so crawling to the service works.