### PR TITLE
Set select query result total to first pass total

### DIFF
--- a/Arriba/Arriba.Test/Model/TableTests.cs
+++ b/Arriba/Arriba.Test/Model/TableTests.cs
@@ -149,7 +149,14 @@ namespace Arriba.Test.Model
         }
 
         [TestMethod]
-        public void Table_All()
+        public void Table_All_SinglePartition()
+        {
+            ITable_All(() => new Table("Sample", 50000));
+
+        }
+
+        [TestMethod]
+        public void Table_All_MultiplePartition()
         {
             ITable_All(() => new Table("Sample", 75000));
         }

--- a/Arriba/Arriba/Model/Query/SelectQuery.cs
+++ b/Arriba/Arriba/Model/Query/SelectQuery.cs
@@ -232,7 +232,15 @@ namespace Arriba.Model.Query
                 }
             }
 
-            return localContext.Compute(p);
+            SelectResult result = localContext.Compute(p);
+
+            if (localContext.Pass1Results != null)
+            {
+                // If this isn't the first pass, use the total from the first pass
+                result.Total = localContext.Pass1Results.Total;
+            }
+
+            return result;
         }
 
         public SelectResult Merge(SelectResult[] partitionResults)

--- a/Arriba/Arriba/Model/Query/SelectQuery.cs
+++ b/Arriba/Arriba/Model/Query/SelectQuery.cs
@@ -255,7 +255,15 @@ namespace Arriba.Model.Query
                 }
             }
 
-            return localContext.Merge(partitionResults);
+            SelectResult result = localContext.Merge(partitionResults);
+
+            if (localContext.Pass1Results != null)
+            {
+                // If this isn't the first pass, use the total from the first pass
+                result.Total = localContext.Pass1Results.Total;
+            }
+
+            return result;
         }
 
         private class SelectContext
@@ -479,15 +487,7 @@ namespace Arriba.Model.Query
                     mergedResult.Details.Merge(partitionResults[i].Details);
                 }
 
-                if (this.Pass1Results == null)
-                {
-                    mergedResult.Total = totalFound;
-                }
-                else
-                {
-                    mergedResult.Total = this.Pass1Results.Total;
-                }
-
+                mergedResult.Total = totalFound;
                 mergedResult.CountReturned = (ushort)Math.Min(this.Count, totalReturned);
 
                 if (mergedResult.Details.Succeeded)


### PR DESCRIPTION
The second pass for the query sets the Total to the result count. Instead, the total from the first pass should be used.