### PR TITLE
Make unit tests a bit more tolerant to issues with new line endings, add margin to min item count

### DIFF
--- a/Arriba/Arriba.Test/Model/TableTests.cs
+++ b/Arriba/Arriba.Test/Model/TableTests.cs
@@ -929,7 +929,7 @@ namespace Arriba.Test.Model
 
             // Add a new column with a non-null default
             string newColumnName = "Area Path";
-            string newColumnInitialDefault = @"5";
+            string newColumnInitialDefault = "5";
             table.AddColumn(new ColumnDetails(newColumnName, "string", newColumnInitialDefault));
 
             // Verify all rows have the new default
@@ -1109,7 +1109,7 @@ namespace Arriba.Test.Model
             string actualValue = GetBlockAsCsv(aggregateBlock);
 
             // Allow extra newlines in values for easier formatting in code.
-            Assert.AreEqual(expectedValue.Trim(), actualValue.Trim());
+            Verify.AreStringsEqual(expectedValue.Trim(), actualValue.Trim());
         }
     }
 }

--- a/Arriba/Arriba.Test/Serialization/CSV/CsvWriterTests.cs
+++ b/Arriba/Arriba.Test/Serialization/CSV/CsvWriterTests.cs
@@ -31,16 +31,17 @@ namespace Arriba.Test.Serialization
                     writer.AppendRow(new object[] { 1524, new DateTime(2014, 01, 03, 0, 0, 0, DateTimeKind.Utc), (ByteBlock)"ByteBlock Value" });
 
                     string expected =
-@"ID,Changed Date,Title" + Environment.NewLine +
-@"1519,2013-12-29 00:00:00Z,Value with no escaping." + Environment.NewLine +
-@"1520,2013-12-30 00:00:00Z,""Value with quote """"escaping"""".""" + Environment.NewLine +
-@"1521,2013-12-31 00:00:00Z,""Value, escaping required.""" + Environment.NewLine +
-@"1522,2014-01-01 00:00:00Z,""Value, escaping and """"quote wrapping"""" required.""" + Environment.NewLine +
-@"1523,2014-01-02 00:00:00Z,""Value" + Environment.NewLine +
-@"requiring escaping.""" + Environment.NewLine +
-@"1524,2014-01-03 00:00:00Z,ByteBlock Value" + Environment.NewLine;
+@"ID,Changed Date,Title
+1519,2013-12-29 00:00:00Z,Value with no escaping.
+1520,2013-12-30 00:00:00Z,""Value with quote """"escaping"""".""
+1521,2013-12-31 00:00:00Z,""Value, escaping required.""
+1522,2014-01-01 00:00:00Z,""Value, escaping and """"quote wrapping"""" required.""
+1523,2014-01-02 00:00:00Z,""Value
+requiring escaping.""
+1524,2014-01-03 00:00:00Z,ByteBlock Value
+";
                     string actual = GetStreamContent(context);
-                    Assert.AreEqual(expected, actual);
+                    Verify.AreStringsEqual(expected, actual);
                 }
 
                 // Verify CsvWriter.Dispose disposed the stream
@@ -64,11 +65,12 @@ namespace Arriba.Test.Serialization
                 writer.AppendRow(new object[] { 1521, new DateTime(2013, 12, 31, 0, 0, 0, DateTimeKind.Utc), "Value, escaping required." });
 
                 string expected =
-@"ID,Changed Date,Title" + Environment.NewLine +
-@"1520,2013-12-30 00:00:00Z,Value with no escaping." + Environment.NewLine +
-@"1521,2013-12-31 00:00:00Z,""Value, escaping required.""" + Environment.NewLine;
+@"ID,Changed Date,Title
+1520,2013-12-30 00:00:00Z,Value with no escaping.
+1521,2013-12-31 00:00:00Z,""Value, escaping required.""
+";
                 string actual = GetStreamContent(context);
-                Assert.AreEqual(expected, actual);
+                Verify.AreStringsEqual(expected, actual);
             }
         }
 
@@ -89,17 +91,18 @@ namespace Arriba.Test.Serialization
                     writer.AppendRow(new object[] { Guid.Empty });
 
                     string expected =
-@"Value" + Environment.NewLine +
-@"" + Environment.NewLine +
-@"True" + Environment.NewLine +
-@"127" + Environment.NewLine +
-@"2013-01-01 00:00:00Z" + Environment.NewLine +
-@"String" + Environment.NewLine +
-@"ByteBlock" + Environment.NewLine +
-@"123" + Environment.NewLine +
-@"00000000-0000-0000-0000-000000000000" + Environment.NewLine;
+@"Value
+
+True
+127
+2013-01-01 00:00:00Z
+String
+ByteBlock
+123
+00000000-0000-0000-0000-000000000000
+";
                     string actual = GetStreamContent(context);
-                    Assert.AreEqual(expected, actual);
+                    Verify.AreStringsEqual(expected, actual);
                 }
             }
         }

--- a/Arriba/Arriba.Test/Structures/ByteBlockTests.cs
+++ b/Arriba/Arriba.Test/Structures/ByteBlockTests.cs
@@ -184,7 +184,7 @@ namespace Arriba.Test.Structures
                 ByteBlock c = "this value is already completely lowercase";
                 c.ToLowerInvariant();
 
-                ByteBlock d = @"Remove Arriba dependencies which aren't easily available in NuGet, so that it's easier for the open source community to consume. Remove Arriba dependencies which aren't easily available in NuGet, so that it's easier for the open source community to consume. Remove Arriba dependencies which aren't easily available in NuGet, so that it's easier for the open source community to consume. Anyway, we need 400 bytes here, so we need a few more...";
+                ByteBlock d = "Remove Arriba dependencies which aren't easily available in NuGet, so that it's easier for the open source community to consume. Remove Arriba dependencies which aren't easily available in NuGet, so that it's easier for the open source community to consume. Remove Arriba dependencies which aren't easily available in NuGet, so that it's easier for the open source community to consume. Anyway, we need 400 bytes here, so we need a few more...";
                 d.ToLowerInvariant();
             }
 

--- a/Arriba/Arriba.Test/Verify.cs
+++ b/Arriba/Arriba.Test/Verify.cs
@@ -4,6 +4,7 @@
 using System;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Arriba.Extensions;
 
 namespace Arriba.Test
 {
@@ -30,6 +31,13 @@ namespace Arriba.Test
                     Assert.AreEqual(expectedMessage, e.Message, "Exception didn't have expected mesage.");
                 }
             }
+        }
+
+        public static void AreStringsEqual(string expected, string actual)
+        {
+            expected = expected.CanonicalizeNewlines();
+            actual = actual.CanonicalizeNewlines();
+            Assert.IsTrue(expected == actual, "{0} != {1}", expected, actual);
         }
     }
 }

--- a/Arriba/Arriba.sln
+++ b/Arriba/Arriba.sln
@@ -38,6 +38,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arriba.TfsWorkItemCrawler", "Tools\Arriba.TfsWorkItemCrawler\Arriba.TfsWorkItemCrawler.csproj", "{FA9A437A-4299-4645-957D-EEABB17396C5}"
 EndProject
 Global
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64

--- a/Arriba/Arriba.sln
+++ b/Arriba/Arriba.sln
@@ -38,9 +38,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arriba.TfsWorkItemCrawler", "Tools\Arriba.TfsWorkItemCrawler\Arriba.TfsWorkItemCrawler.csproj", "{FA9A437A-4299-4645-957D-EEABB17396C5}"
 EndProject
 Global
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64

--- a/Arriba/Arriba/Model/Table.cs
+++ b/Arriba/Arriba/Model/Table.cs
@@ -46,6 +46,10 @@ namespace Arriba.Model
         {
             this.Name = tableName;
 
+            // Pad the min row count by 5% to account for imperfect distribution of items
+            // based on the hashing algorithm.
+            long paddedMinItemCount = (long)(requiredItemCount * 1.05);
+
             // Translate the item limit to a number of partition bits (64k items per partition)
             _partitionBits = (byte)Math.Max(Math.Ceiling(Math.Log(requiredItemCount, 2)) - 16, 0);
 


### PR DESCRIPTION
The unit tests that do string literal comparisons can fail based on GIT new line handling.  This change canonicalizes the new lines before comparing to compensate for that.

Fix an issue where DBs created with min row counts near the partition boundaries can fail to add the required rows because of imperfect hash distribution.  Fix is to pad the item counts by a small margin (5%) when deciding partition counts.