### PR TITLE
LDFReader, String8 work

### DIFF
--- a/Elfie/Elfie.Test/Elfie.Test.csproj
+++ b/Elfie/Elfie.Test/Elfie.Test.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Serialization\IISLogReaderTests.cs" />
     <Compile Include="Serialization\ITabularValueTests.cs" />
     <Compile Include="Serialization\JsonTabularWriterTests.cs" />
+    <Compile Include="Serialization\LDFReaderTests.cs" />
     <Compile Include="Serialization\TsvWriterTests.cs" />
     <Compile Include="Verify.cs" />
   </ItemGroup>

--- a/Elfie/Elfie.Test/Model/Strings/String8Tests.cs
+++ b/Elfie/Elfie.Test/Model/Strings/String8Tests.cs
@@ -184,6 +184,17 @@ namespace Microsoft.CodeAnalysis.Elfie.Test.Model.Strings
         }
 
         [TestMethod]
+        public void String8_TrimEnd()
+        {
+            String8 sample = "Interesting   ".TestConvert();
+            Assert.AreEqual("Interesting", sample.TrimEnd(UTF8.Space).ToString());
+            Assert.AreEqual(sample.ToString(), sample.TrimEnd(UTF8.Tab).ToString());
+            Assert.AreEqual(string.Empty, String8.Empty.TrimEnd(UTF8.Space).ToString());
+            Assert.AreEqual(string.Empty, "   ".TestConvert().TrimEnd(UTF8.Space).ToString());
+            Assert.AreEqual("A", "A   ".TestConvert().TrimEnd(UTF8.Space).ToString());
+        }
+
+        [TestMethod]
         public void String8_StartsWithEndsWith()
         {
             string collections = "Collections";

--- a/Elfie/Elfie.Test/Model/Strings/String8Tests.cs
+++ b/Elfie/Elfie.Test/Model/Strings/String8Tests.cs
@@ -266,35 +266,47 @@ namespace Microsoft.CodeAnalysis.Elfie.Test.Model.Strings
         }
 
         [TestMethod]
-        public void String8_TryToInteger()
+        public void String8_NumberConversions()
         {
-            Assert.AreEqual(null, TryToInteger(null));
-            Assert.AreEqual(null, TryToInteger(String.Empty));
-            Assert.AreEqual(5, TryToInteger("5"));
-            Assert.AreEqual(12345, TryToInteger("12345"));
-            Assert.AreEqual(-6, TryToInteger("-6"));
-            Assert.AreEqual(-1, TryToInteger("-1"));
-            Assert.AreEqual(0, TryToInteger("0"));
-            Assert.AreEqual(1, TryToInteger("1"));
-            Assert.AreEqual(int.MaxValue, TryToInteger(int.MaxValue.ToString()));
-            Assert.AreEqual(int.MinValue, TryToInteger(int.MinValue.ToString()));
-            Assert.AreEqual(null, TryToInteger("123g"));
-            Assert.AreEqual(null, TryToInteger("9999999999"));
-            Assert.AreEqual(null, TryToInteger("12345678901234567890"));
+            TryNumberConversions("-0");
+
+            TryNumberConversions(null);
+            TryNumberConversions(string.Empty);
+            TryNumberConversions("0");
+            TryNumberConversions("-1");
+            TryNumberConversions("1");
+            TryNumberConversions("--1");
+            TryNumberConversions("123A");
+            TryNumberConversions(int.MinValue.ToString());
+            TryNumberConversions(int.MaxValue.ToString());
+            TryNumberConversions(((long)int.MaxValue + 1).ToString());
+            TryNumberConversions(long.MinValue.ToString());
+            TryNumberConversions(long.MaxValue.ToString());
+            TryNumberConversions(((ulong)long.MaxValue + 1).ToString());
+            TryNumberConversions(ulong.MaxValue.ToString());
+            TryNumberConversions("18446744073709551616"); // ulong.MaxValue + 1
+            TryNumberConversions(ulong.MaxValue.ToString() + "0");
         }
 
-        private int? TryToInteger(string value)
+        private static void TryNumberConversions(string value)
         {
             String8 value8 = value.TestConvert();
 
-            int? result = null;
-            int parsed = 0;
-            if (value8.TryToInteger(out parsed))
-            {
-                result = parsed;
-            }
+            // .NET Parses "-0" successfully as int and long, but not ulong.
+            // I don't want "-0" to be considered valid on any parse.
+            if (value == "-0") value = "Invalid";
 
-            return result;
+            int expectedInt, actualInt;
+            Assert.AreEqual(int.TryParse(value, out expectedInt), value8.TryToInteger(out actualInt));
+            Assert.AreEqual(expectedInt, actualInt);
+
+            long expectedLong, actualLong;
+            Assert.AreEqual(long.TryParse(value, out expectedLong), value8.TryToLong(out actualLong));
+            Assert.AreEqual(expectedLong, actualLong);
+
+            ulong expectedULong, actualULong;
+            Assert.AreEqual(ulong.TryParse(value, out expectedULong), value8.TryToULong(out actualULong));
+            Assert.AreEqual(expectedULong, actualULong);
         }
 
         [TestMethod]

--- a/Elfie/Elfie.Test/Model/Strings/String8Tests.cs
+++ b/Elfie/Elfie.Test/Model/Strings/String8Tests.cs
@@ -174,6 +174,44 @@ namespace Microsoft.CodeAnalysis.Elfie.Test.Model.Strings
         }
 
         [TestMethod]
+        public void String8_StartsWithEndsWith()
+        {
+            string collections = "Collections";
+            String8 collections8 = String8.Convert(collections, new byte[String8.GetLength(collections)]);
+
+            string collectionsCasing = "coLLecTionS";
+            String8 collectionsCasing8 = String8.Convert(collectionsCasing, new byte[String8.GetLength(collectionsCasing)]);
+
+            Assert.IsFalse(String8.Empty.StartsWith(UTF8.Space));
+            Assert.IsFalse(String8.Empty.EndsWith(UTF8.Space));
+
+            Assert.IsTrue(collections8.StartsWith((byte)'C'));
+            Assert.IsFalse(collections8.StartsWith((byte)'c'));
+            Assert.IsFalse(collections8.StartsWith(UTF8.Newline));
+
+            Assert.IsTrue(collections8.EndsWith((byte)'s'));
+            Assert.IsFalse(collections8.EndsWith((byte)'S'));
+            Assert.IsFalse(collections8.EndsWith(UTF8.Newline));
+
+            Assert.IsFalse(String8.Empty.StartsWith(collections8));
+            Assert.IsFalse(String8.Empty.EndsWith(collections8));
+            Assert.IsFalse(String8.Empty.StartsWith(collections8, true));
+            Assert.IsFalse(String8.Empty.EndsWith(collections8, true));
+
+            Assert.IsTrue(collections8.EndsWith(collections8));
+            Assert.IsTrue(collections8.EndsWith(collections8.Substring(1)));
+            Assert.IsTrue(collections8.EndsWith(collections8.Substring(8)));
+            Assert.IsFalse(collections8.EndsWith(collectionsCasing8));
+            Assert.IsTrue(collections8.EndsWith(collectionsCasing8, true));
+
+            Assert.IsTrue(collections8.StartsWith(collections8));
+            Assert.IsTrue(collections8.StartsWith(collections8.Substring(0, collections8.Length - 1)));
+            Assert.IsTrue(collections8.StartsWith(collections8.Substring(0, 3)));
+            Assert.IsFalse(collections8.StartsWith(collectionsCasing8));
+            Assert.IsTrue(collections8.StartsWith(collectionsCasing8, true));
+        }
+
+        [TestMethod]
         public void String8_Prefix()
         {
             String8 full = String8.Convert("One.Two.Three", new byte[13]);

--- a/Elfie/Elfie.Test/Serialization/LDFReaderTests.cs
+++ b/Elfie/Elfie.Test/Serialization/LDFReaderTests.cs
@@ -7,7 +7,8 @@ namespace Microsoft.CodeAnalysis.Elfie.Test.Serialization
     [TestClass]
     public class LDFReaderTests
     {
-        private const string SampleContent = @"dn: CN=Scott Louvau,OU=UserAccounts,DC=domain,DC=com
+        private const string SampleContent = @"#Comment
+dn: CN=Scott Louvau,OU=UserAccounts,DC=domain,DC=com
 changetype: add
 cn: Scott Louvau
 whenCreated: 19990410024913.0Z

--- a/Elfie/Elfie.Test/Serialization/LDFReaderTests.cs
+++ b/Elfie/Elfie.Test/Serialization/LDFReaderTests.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.CodeAnalysis.Elfie.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.Elfie.Test.Serialization
+{
+    [TestClass]
+    public class LDFReaderTests
+    {
+        private const string SampleContent = @"dn: CN=Scott Louvau,OU=UserAccounts,DC=domain,DC=com
+changetype: add
+cn: Scott Louvau
+whenCreated: 19990410024913.0Z
+whenChanged: 20170922025542.0Z
+pwdLastSet: 131505223204018920
+objectSid:: AQUAAAAAAAUVAAAAFdoFDGWeMwFVdzMB9AEAAA==
+distinguishedName: 
+ CN=Scott Louvau,OU=UserAccounts,DC=domain,DC=com
+memberOf: 
+ CN=Interesting Group,OU=Distribution Lists,DC=domain,DC=com
+memberOf: 
+ CN=Another Group,OU=Distribution Lists,DC=domain,DC=com
+memberOf: 
+ CN=Wrapped Group,OU=Specific OU,OU=Container OU
+ ,OU=Resources,DC=domain,DC=com
+
+dn: CN=Second User,OU=UserAccounts,DC=domain,DC=com
+changetype: add
+cn: Second User
+
+dn: CN=Third User,OU=UserAccounts,DC=domain,DC=com
+changetype: add
+cn: Third User
+objectSid:: AQUAAAAAAAUVAAAAF
+ doFDGWeMwFVdzMB9AEAAA==";
+
+        [TestMethod]
+        public void LDFReader_Basics()
+        {
+            File.WriteAllText("Sample.ldf", SampleContent);
+
+            using (ITabularReader reader = new LDFTabularReader("Sample.ldf"))
+            {
+                // Validate column names found
+                Assert.AreEqual("dn, changetype, cn, whenCreated, whenChanged, pwdLastSet, objectSid, distinguishedName, memberOf", string.Join(", ", reader.Columns));
+
+                while (reader.NextRow())
+                {
+                    // Spot Check values
+                    Assert.AreEqual("2017-05-13", reader.Current(0).ToString());
+                    Assert.AreEqual("10.10.1.1", reader.Current(2).ToString());
+                    Assert.AreEqual("GET", reader.Current(3).ToString());
+                    Assert.AreEqual("https://arriba/", reader.Current(10).ToString());
+                }
+
+                // Validate row count read
+                Assert.AreEqual(7, reader.RowCountRead);
+            }
+        }
+    }
+}

--- a/Elfie/Elfie.Test/Serialization/LDFReaderTests.cs
+++ b/Elfie/Elfie.Test/Serialization/LDFReaderTests.cs
@@ -31,6 +31,7 @@ cn: Second User
 dn: CN=Third User,OU=UserAccounts,DC=domain,DC=com
 changetype: add
 cn: Third User
+lockoutTime: 131505223204018920
 objectSid:: AQUAAAAAAAUVAAAAF
  doFDGWeMwFVdzMB9AEAAA==";
 
@@ -39,22 +40,55 @@ objectSid:: AQUAAAAAAAUVAAAAF
         {
             File.WriteAllText("Sample.ldf", SampleContent);
 
+            int colIndex;
             using (ITabularReader reader = new LdfTabularReader("Sample.ldf"))
             {
                 // Validate column names found
-                Assert.AreEqual("dn, changetype, cn, whenCreated, whenChanged, pwdLastSet, objectSid, distinguishedName, memberOf", string.Join(", ", reader.Columns));
+                Assert.AreEqual("dn, changetype, cn, whenCreated, whenChanged, pwdLastSet, objectSid, distinguishedName, memberOf, lockoutTime", string.Join(", ", reader.Columns));
 
-                while (reader.NextRow())
+                colIndex = 0;
+                Assert.IsTrue(reader.NextRow());
+                Assert.AreEqual(10, reader.CurrentRowColumns);
+                Assert.AreEqual("CN=Scott Louvau,OU=UserAccounts,DC=domain,DC=com", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("add", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("Scott Louvau", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("19990410024913.0Z", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("20170922025542.0Z", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("131505223204018920", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("S-1-5-21-201710101-20160101-20150101-500", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("CN=Scott Louvau,OU=UserAccounts,DC=domain,DC=com", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("CN=Interesting Group,OU=Distribution Lists,DC=domain,DC=com;CN=Another Group,OU=Distribution Lists,DC=domain,DC=com;CN=Wrapped Group,OU=Specific OU,OU=Container OU,OU=Resources,DC=domain,DC=com", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("", reader.Current(colIndex++).ToString());
+
+                colIndex = 0;
+                Assert.IsTrue(reader.NextRow());
+                Assert.AreEqual(10, reader.CurrentRowColumns);
+                Assert.AreEqual("CN=Second User,OU=UserAccounts,DC=domain,DC=com", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("add", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("Second User", reader.Current(colIndex++).ToString());
+                while (colIndex < reader.CurrentRowColumns)
                 {
-                    // Spot Check values
-                    Assert.AreEqual("2017-05-13", reader.Current(0).ToString());
-                    Assert.AreEqual("10.10.1.1", reader.Current(2).ToString());
-                    Assert.AreEqual("GET", reader.Current(3).ToString());
-                    Assert.AreEqual("https://arriba/", reader.Current(10).ToString());
+                    Assert.AreEqual("", reader.Current(colIndex++).ToString());
                 }
 
+                colIndex = 0;
+                Assert.IsTrue(reader.NextRow());
+                Assert.AreEqual(10, reader.CurrentRowColumns);
+                Assert.AreEqual("CN=Third User,OU=UserAccounts,DC=domain,DC=com", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("add", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("Third User", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("S-1-5-21-201710101-20160101-20150101-500", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("", reader.Current(colIndex++).ToString());
+                Assert.AreEqual("131505223204018920", reader.Current(colIndex++).ToString());
+
+                Assert.IsFalse(reader.NextRow());
+
                 // Validate row count read
-                Assert.AreEqual(7, reader.RowCountRead);
+                Assert.AreEqual(3, reader.RowCountRead);
             }
         }
     }

--- a/Elfie/Elfie.Test/Serialization/LDFReaderTests.cs
+++ b/Elfie/Elfie.Test/Serialization/LDFReaderTests.cs
@@ -39,7 +39,7 @@ objectSid:: AQUAAAAAAAUVAAAAF
         {
             File.WriteAllText("Sample.ldf", SampleContent);
 
-            using (ITabularReader reader = new LDFTabularReader("Sample.ldf"))
+            using (ITabularReader reader = new LdfTabularReader("Sample.ldf"))
             {
                 // Validate column names found
                 Assert.AreEqual("dn, changetype, cn, whenCreated, whenChanged, pwdLastSet, objectSid, distinguishedName, memberOf", string.Join(", ", reader.Columns));

--- a/Elfie/Elfie/Elfie.csproj
+++ b/Elfie/Elfie/Elfie.csproj
@@ -145,7 +145,7 @@
     <Compile Include="Serialization\ITabularReader.cs" />
     <Compile Include="Serialization\ITabularWriter.cs" />
     <Compile Include="Serialization\JsonTabularWriter.cs" />
-    <Compile Include="Serialization\LDFTabularReader.cs" />
+    <Compile Include="Serialization\LdfTabularReader.cs" />
     <Compile Include="Serialization\Read.cs" />
     <Compile Include="Model\Strings\String8Block.cs" />
     <Compile Include="Serialization\BaseTabularReader.cs" />

--- a/Elfie/Elfie/Elfie.csproj
+++ b/Elfie/Elfie/Elfie.csproj
@@ -135,6 +135,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="Serialization\BaseTabularWriter.cs" />
+    <Compile Include="Serialization\BufferedRowReader.cs" />
     <Compile Include="Serialization\ConsoleTabularWriter.cs" />
     <Compile Include="Serialization\DataReaderTabularReader.cs" />
     <Compile Include="Serialization\FileIO.cs" />

--- a/Elfie/Elfie/Elfie.csproj
+++ b/Elfie/Elfie/Elfie.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Serialization\ITabularReader.cs" />
     <Compile Include="Serialization\ITabularWriter.cs" />
     <Compile Include="Serialization\JsonTabularWriter.cs" />
+    <Compile Include="Serialization\LDFTabularReader.cs" />
     <Compile Include="Serialization\Read.cs" />
     <Compile Include="Model\Strings\String8Block.cs" />
     <Compile Include="Serialization\BaseTabularReader.cs" />

--- a/Elfie/Elfie/Model/Strings/String8.cs
+++ b/Elfie/Elfie/Model/Strings/String8.cs
@@ -348,6 +348,22 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
         }
 
         /// <summary>
+        ///  Return this string with all trailing 'c's removed.
+        /// </summary>
+        /// <param name="c">Character to trim</param>
+        /// <returns>String8 without any trailing copies of c</returns>
+        public String8 TrimEnd(byte c)
+        {
+            int index = _index + _length - 1;
+            for(; index >= _index; --index)
+            {
+                if (_buffer[index] != c) break;
+            }
+
+            return new String8(_buffer, _index, index - _index + 1);
+        }
+
+        /// <summary>
         ///  Return whether this string ends with the given character.
         /// </summary>
         /// <param name="c">Character to check for</param>

--- a/Elfie/Elfie/Model/Strings/String8.cs
+++ b/Elfie/Elfie/Model/Strings/String8.cs
@@ -926,6 +926,17 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
 
         #region Output
         /// <summary>
+        ///  Move this String8 backwards in the byte array by the specified number of bytes.
+        ///  Used to un-escape values escaped with extra characters.
+        /// </summary>
+        /// <param name="byteCount">Number of byte to shift this string</param>
+        public void ShiftBack(int byteCount)
+        {
+            if (this._index < byteCount) throw new ArgumentOutOfRangeException("amount");
+            System.Buffer.BlockCopy(_buffer, _index, _buffer, _index - byteCount, _length);
+        }
+
+        /// <summary>
         ///  Write this value to the target byte[] at the given index as UTF8.
         /// </summary>
         /// <param name="buffer">byte[] to write to</param>

--- a/Elfie/Elfie/Model/Strings/String8.cs
+++ b/Elfie/Elfie/Model/Strings/String8.cs
@@ -734,20 +734,19 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
         {
             result = DateTime.MinValue;
 
-            int year, month, day;
+            uint year, month, day;
 
             // Parse the date numbers
-            if (!this.Substring(yearIndex, 4).TryToInteger(out year)) return false;
-            if (!this.Substring(monthIndex, 2).TryToInteger(out month)) return false;
-            if (!this.Substring(dayIndex, 2).TryToInteger(out day)) return false;
+            if (!this.Substring(yearIndex, 4).TryToUInt(out year)) return false;
+            if (!this.Substring(monthIndex, 2).TryToUInt(out month)) return false;
+            if (!this.Substring(dayIndex, 2).TryToUInt(out day)) return false;
 
             // Validate the date number ranges (no month-specific day validation)
-            if (year < 0) return false;
             if (month < 1 || month > 12) return false;
             if (day < 1 || day > 31) return false;
 
             // Construct DateTime to avoid failures due to days being out of range (leap year and month length)
-            result = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Utc);
+            result = new DateTime((int)year, (int)month, 1, 0, 0, 0, DateTimeKind.Utc);
             if (day > 1) result = result.AddDays(day - 1);
 
             // Return false for invalid leap days
@@ -769,20 +768,20 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
             // Convert the Date first
             if (!TryToDateTimeExact(out result, yearIndex, monthIndex, dayIndex)) return false;
 
-            int hour, minute, second;
+            uint hour, minute, second;
 
             // Parse the time numbers
-            if (!this.Substring(11, 2).TryToInteger(out hour)) return false;
-            if (!this.Substring(14, 2).TryToInteger(out minute)) return false;
-            if (!this.Substring(17, 2).TryToInteger(out second)) return false;
+            if (!this.Substring(11, 2).TryToUInt(out hour)) return false;
+            if (!this.Substring(14, 2).TryToUInt(out minute)) return false;
+            if (!this.Substring(17, 2).TryToUInt(out second)) return false;
 
             // Validate the time number ranges
-            if (hour < 0 || hour > 23) return false;
-            if (minute < 0 || minute > 59) return false;
-            if (second < 0 || second > 59) return false;
+            if (hour > 23) return false;
+            if (minute > 59) return false;
+            if (second > 59) return false;
 
             // Add the time part
-            result = result.Add(new TimeSpan(hour, minute, second));
+            result = result.Add(new TimeSpan((int)hour, (int)minute, (int)second));
 
             return true;
         }

--- a/Elfie/Elfie/Model/Strings/String8.cs
+++ b/Elfie/Elfie/Model/Strings/String8.cs
@@ -352,6 +352,17 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
         /// </summary>
         /// <param name="c">Character to check for</param>
         /// <returns>True if string ends with character, false otherwise</returns>
+        public bool StartsWith(byte c)
+        {
+            if (_length == 0) return false;
+            return (_buffer[0] == c);
+        }
+
+        /// <summary>
+        ///  Return whether this string ends with the given character.
+        /// </summary>
+        /// <param name="c">Character to check for</param>
+        /// <returns>True if string ends with character, false otherwise</returns>
         public bool EndsWith(byte c)
         {
             if (_length == 0) return false;
@@ -367,6 +378,18 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
         public bool StartsWith(String8 other, bool ignoreCase = false)
         {
             return other.CompareAsPrefixTo(this, ignoreCase) == 0;
+        }
+
+        /// <summary>
+        ///  Return whether this string starts with the given other string.
+        /// </summary>
+        /// <param name="other">The potential prefix to this string</param>
+        /// <param name="ignoreCase">True for case insensitive comparison, False otherwise</param>
+        /// <returns></returns>
+        public bool EndsWith(String8 other, bool ignoreCase = false)
+        {
+            if (other.Length > this.Length) return false;
+            return other.CompareTo(this.Substring(this.Length - other.Length), ignoreCase) == 0;
         }
 
         /// <summary>

--- a/Elfie/Elfie/Model/Strings/String8.cs
+++ b/Elfie/Elfie/Model/Strings/String8.cs
@@ -462,6 +462,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
             ulong value = 0;
 
             // Convert the digits
+            // NOTE: Don't need to check digits valid, because even 19 255 digits won't overflow
             int end = _index + _length;
             for (int i = _index; i < end; ++i)
             {

--- a/Elfie/Elfie/Model/Strings/String8.cs
+++ b/Elfie/Elfie/Model/Strings/String8.cs
@@ -559,14 +559,18 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
 
             if (_length < 20)
             {
-                // Not max length: Parse without bounds check
+                // Not max length: Parse normally
                 result = ParseWithCutoff(ulong.MaxValue, ref valid);
             }
             else
             {
-                // Max Length: Parse all but last digit, check bounds, finish converting
+                // Max Length: Parse all but last digit
                 result = 10 * this.Substring(0, this.Length - 1).ParseWithCutoff(ulong.MaxValue / 10, ref valid);
+
+                // Limit Last digit so sum is <= ulong.MaxValue
                 result += this.Substring(this.Length - 1).ParseWithCutoff(ulong.MaxValue - result, ref valid);
+
+                // Ensure overflows are reset to zero
                 if (!valid) result = 0;
             }
 

--- a/Elfie/Elfie/Model/Strings/String8.cs
+++ b/Elfie/Elfie/Model/Strings/String8.cs
@@ -355,7 +355,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
         public bool StartsWith(byte c)
         {
             if (_length == 0) return false;
-            return (_buffer[0] == c);
+            return (_buffer[_index] == c);
         }
 
         /// <summary>

--- a/Elfie/Elfie/Model/Strings/UTF8.cs
+++ b/Elfie/Elfie/Model/Strings/UTF8.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Model.Strings
         public const byte Newline = (byte)'\n';
         public const byte Space = (byte)' ';
         public const byte Colon = (byte)':';
+        public const byte Semicolon = (byte)';';
         public const byte a = (byte)'a';
         public const byte z = (byte)'z';
         public const byte A = (byte)'A';

--- a/Elfie/Elfie/Serialization/BaseTabularReader.cs
+++ b/Elfie/Elfie/Serialization/BaseTabularReader.cs
@@ -111,15 +111,6 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
         // Break a block from the file into contiguous ranges for each logical row
         protected abstract String8Set SplitRows(String8 block, PartialArray<int> rowPositionArray);
 
-        // Identify where the values are for each column in the current row
-        protected virtual void SplitValues(String8Set rowCells, String8TabularValue[] rowValues)
-        {
-            for(int i = 0; i < rowCells.Count; ++i)
-            {
-                rowValues[i].SetValue(rowCells[i]);
-            }
-        }
-
         /// <summary>
         ///  Return the column headings found. The set is empty if there was no heading row.
         /// </summary>
@@ -157,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
         /// <returns>String8Set with the cells for the current row.</returns>
         public ITabularValue Current(int index)
         {
-            if (index >= _currentRowColumns.Count) throw new ArgumentOutOfRangeException();
+            _valueBoxes[index].SetValue(_currentRowColumns[index]);
             return _valueBoxes[index];
         }
 
@@ -209,9 +200,6 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
                     _valueBoxes[i] = new String8TabularValue();
                 }
             }
-
-            // Get the value portions of the cells into String8TabularValues
-            SplitValues(_currentRowColumns, _valueBoxes);
 
             return true;
         }

--- a/Elfie/Elfie/Serialization/BaseTabularReader.cs
+++ b/Elfie/Elfie/Serialization/BaseTabularReader.cs
@@ -55,16 +55,12 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
     /// </summary>
     public abstract class BaseTabularReader : ITabularReader
     {
-        private Stream _reader;
+        private BufferedRowReader _reader;
 
         protected List<string> _columnHeadingsList;
         protected Dictionary<string, int> _columnHeadings;
 
-        private byte[] _buffer;
-        private int _nextRowIndexInBlock;
-        private String8Set _currentBlock;
-        private String8Set _currentRow;
-        private PartialArray<int> _rowPositionArray;
+        private String8Set _currentRowColumns;
         private PartialArray<int> _cellPositionArray;
 
         private String8TabularValue[] _valueBoxes;
@@ -85,14 +81,11 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
         /// <param name="hasHeaderRow">True to read the first row as column names, False not to pre-read anything</param>
         public BaseTabularReader(Stream stream, bool hasHeaderRow = true)
         {
-            _reader = stream;
+            _reader = new BufferedRowReader(stream, SplitRows);
 
             _columnHeadingsList = new List<string>();
             _columnHeadings = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
-            _buffer = new byte[64 * 1024];
-            _nextRowIndexInBlock = 0;
-            _rowPositionArray = new PartialArray<int>(64, false);
             _cellPositionArray = new PartialArray<int>(1024, false);
 
             // Read the heading row and record heading positions
@@ -100,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
             {
                 if (!NextRow()) throw new IOException("Reader didn't find any rows when trying to read a header row.");
 
-                for (int i = 0; i < _currentRow.Count; ++i)
+                for (int i = 0; i < _currentRowColumns.Count; ++i)
                 {
                     string columnName = this.Current(i).ToString();
                     _columnHeadingsList.Add(columnName);
@@ -164,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
         /// <returns>String8Set with the cells for the current row.</returns>
         public ITabularValue Current(int index)
         {
-            if (index >= _currentRow.Count) throw new ArgumentOutOfRangeException();
+            if (index >= _currentRowColumns.Count) throw new ArgumentOutOfRangeException();
             return _valueBoxes[index];
         }
 
@@ -179,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
         /// </summary>
         public long BytesRead
         {
-            get { return _reader.Position; }
+            get { return _reader.BytesRead; }
         }
 
         /// <summary>
@@ -188,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
         /// </summary>
         public int CurrentRowColumns
         {
-            get { return _currentRow.Count; }
+            get { return _currentRowColumns.Count; }
         }
 
         /// <summary>
@@ -198,37 +191,18 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
         /// <returns>True if another row exists, False if the TSV is out of content</returns>
         public virtual bool NextRow()
         {
-            // If we're on the last row, ask for more (we don't read the last row in case it was only partially read into the buffer)
-            if (_nextRowIndexInBlock >= _currentBlock.Count - 1)
-            {
-                NextBlock();
-            }
-
-            // If there are no more rows, return false
-            if (_nextRowIndexInBlock >= _currentBlock.Count) return false;
-
-            // Get the next (complete) row from the current block
-            String8 currentLine = _currentBlock[_nextRowIndexInBlock];
-
-            // Strip leading UTF8 BOM, if found, on first row
-            if (this.RowCountRead == 0)
-            {
-                if (currentLine.Length >= 3 && currentLine[0] == 0xEF && currentLine[1] == 0xBB && currentLine[2] == 0xBF)
-                {
-                    currentLine = currentLine.Substring(3);
-                }
-            }
+            String8 row = _reader.NextRow();
+            if (row.IsEmpty()) return false;
 
             // Split the line into cells
-            _currentRow = SplitCells(currentLine, _cellPositionArray);
+            _currentRowColumns = SplitCells(row, _cellPositionArray);
 
             this.RowCountRead++;
-            _nextRowIndexInBlock++;
 
             // Allocate a set of reusable String8TabularValues to avoid per-cell-value allocation or boxing.
-            if (_valueBoxes == null || _valueBoxes.Length < _currentRow.Count)
+            if (_valueBoxes == null || _valueBoxes.Length < _currentRowColumns.Count)
             {
-                _valueBoxes = new String8TabularValue[_currentRow.Count];
+                _valueBoxes = new String8TabularValue[_currentRowColumns.Count];
 
                 for (int i = 0; i < _valueBoxes.Length; ++i)
                 {
@@ -237,74 +211,9 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
             }
 
             // Get the value portions of the cells into String8TabularValues
-            SplitValues(_currentRow, _valueBoxes);
+            SplitValues(_currentRowColumns, _valueBoxes);
 
             return true;
-        }
-
-        /// <summary>
-        ///  NextBlock is called by NextRow before reading the last row in _currentBlock.
-        ///  Since the file is read in blocks, the last row is usually incomplete.
-        ///  
-        ///  If there's more file content, NextBlock should copy the last row to the start
-        ///  of the buffer, read more content, and reset _currentBlock to the new split rows
-        ///  and _nextRowIndexInBlock to zero (telling NextRow to read that row next).
-        ///  
-        ///  If there's no more file, the last row is complete. NextBlock must return
-        ///  without changing _currentBlock or _nextRowIndexInBlock to tell NextRow it's safe
-        ///  to return to the user.
-        ///  
-        ///  NextRow will call NextBlock *again* after the last row. NextBlock must again
-        ///  not change anything to tell NextRow that there's nothing left.
-        ///  
-        ///  So, NextBlock must:
-        ///   - Copy the last row to the start of the buffer (if not already there)
-        ///   - Read more content to fill the buffer
-        ///   - Split the buffer into rows
-        ///   - Stop at end-of-file or when a full row was read
-        ///   - Double the buffer until one of these conditions is met
-        ///   
-        ///   - Reset nextRowInIndexBlock *only if* a row was shifted or read
-        /// </summary>
-        private void NextBlock()
-        {
-            int bufferLengthFilledStart = 0;
-
-            // Copy the last row to the start of the buffer (if not already there)
-            if (_currentBlock.Count > 1)
-            {
-                String8 lastRow = _currentBlock[_currentBlock.Count - 1];
-                lastRow.WriteTo(_buffer, 0);
-                bufferLengthFilledStart = lastRow.Length;
-
-                // Reset the next row to read (since we shifted a row)
-                _nextRowIndexInBlock = 0;
-            }
-
-            int bufferLengthFilled = bufferLengthFilledStart;
-
-            while (true)
-            {
-                // Read more content to fill the buffer
-                bufferLengthFilled += _reader.Read(_buffer, bufferLengthFilled, _buffer.Length - bufferLengthFilled);
-
-                // Split the buffer into rows
-                _currentBlock = SplitRows(new String8(_buffer, 0, bufferLengthFilled), _rowPositionArray);
-
-                // Stop at end-of-file (read didn't fill buffer)
-                if (bufferLengthFilled < _buffer.Length) break;
-
-                // Stop when a full row was read (split found at least two parts)
-                if (_currentBlock.Count > 1) break;
-
-                // Otherwise, double the buffer (until a full row or end of file)
-                byte[] newBuffer = new byte[_buffer.Length * 2];
-                _buffer.CopyTo(newBuffer, 0);
-                _buffer = newBuffer;
-            }
-
-            // If we read new content, reset the next row to read
-            if (bufferLengthFilled > bufferLengthFilledStart) _nextRowIndexInBlock = 0;
         }
 
         public void Dispose()

--- a/Elfie/Elfie/Serialization/BufferedRowReader.cs
+++ b/Elfie/Elfie/Serialization/BufferedRowReader.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.Elfie.Model.Strings;
+using Microsoft.CodeAnalysis.Elfie.Model.Structures;
+using System;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.Elfie.Serialization
+{
+    /// <summary>
+    ///  BufferedRowReader reads rows from a file in blocks, given a row splitting function.
+    ///  It ensures readers don't get partial rows by only returning rows before the last until
+    ///  the file is fully read.
+    /// </summary>
+    public class BufferedRowReader : IDisposable
+    {
+        private Stream _stream;
+        private Func<String8, PartialArray<int>, String8Set> _splitRows;
+
+        private byte[] _buffer;
+        private PartialArray<int> _rowPositionArray;
+        private int _nextRowIndexInBlock;
+        private String8Set _currentBlock;
+        private String8 _currentRow;
+
+        public BufferedRowReader(Stream stream, Func<String8, PartialArray<int>, String8Set> splitRows)
+        {
+            _stream = stream;
+            _splitRows = splitRows;
+
+            _buffer = new byte[Math.Min(stream.Length + 1, 64 * 1024)];
+            _rowPositionArray = new PartialArray<int>(64, false);
+        }
+
+        public long BytesRead => _stream.Position;
+
+        /// <summary>
+        ///  Move the reader to the next row. This must be called before
+        ///  reading the first row.
+        /// </summary>
+        /// <returns>True if another row exists, False if the TSV is out of content</returns>
+        public String8 NextRow()
+        {
+            // If we're on the last row, ask for more (we don't read the last row in case it was only partially read into the buffer)
+            if (_nextRowIndexInBlock >= _currentBlock.Count - 1)
+            {
+                NextBlock();
+            }
+
+            // If there are no more rows, return false
+            if (_nextRowIndexInBlock >= _currentBlock.Count) return String8.Empty;
+
+            // Get the next (complete) row from the current block
+            _currentRow = _currentBlock[_nextRowIndexInBlock];
+
+            _nextRowIndexInBlock++;
+            return _currentRow;
+        }
+
+        /// <summary>
+        ///  NextBlock is called by NextRow before reading the last row in _currentBlock.
+        ///  Since the file is read in blocks, the last row is usually incomplete.
+        ///  
+        ///  If there's more file content, NextBlock should copy the last row to the start
+        ///  of the buffer, read more content, and reset _currentBlock to the new split rows
+        ///  and _nextRowIndexInBlock to zero (telling NextRow to read that row next).
+        ///  
+        ///  If there's no more file, the last row is complete. NextBlock must return
+        ///  without changing _currentBlock or _nextRowIndexInBlock to tell NextRow it's safe
+        ///  to return to the user.
+        ///  
+        ///  NextRow will call NextBlock *again* after the last row. NextBlock must again
+        ///  not change anything to tell NextRow that there's nothing left.
+        ///  
+        ///  So, NextBlock must:
+        ///   - Copy the last row to the start of the buffer (if not already there)
+        ///   - Read more content to fill the buffer
+        ///   - Split the buffer into rows
+        ///   - Stop at end-of-file or when a full row was read
+        ///   - Double the buffer until one of these conditions is met
+        ///   
+        ///   - Reset nextRowInIndexBlock *only if* a row was shifted or read
+        /// </summary>
+        private void NextBlock()
+        {
+            int bufferLengthFilledStart = 0;
+
+            // Copy the last row to the start of the buffer (if not already there)
+            if (_currentBlock.Count > 1)
+            {
+                String8 lastRow = _currentBlock[_currentBlock.Count - 1];
+                lastRow.WriteTo(_buffer, 0);
+                bufferLengthFilledStart = lastRow.Length;
+
+                // Reset the next row to read (since we shifted a row)
+                _nextRowIndexInBlock = 0;
+            }
+
+            int bufferLengthFilled = bufferLengthFilledStart;
+
+            while (true)
+            {
+                // Read more content to fill the buffer
+                bufferLengthFilled += _stream.Read(_buffer, bufferLengthFilled, _buffer.Length - bufferLengthFilled);
+
+                String8 block = new String8(_buffer, 0, bufferLengthFilled);
+
+                // Strip leading UTF8 BOM, if found, on first block
+                if (_stream.Position == bufferLengthFilled)
+                {
+                    if (block.Length >= 3 && block[0] == 0xEF && block[1] == 0xBB && block[2] == 0xBF) block = block.Substring(3);
+                }
+
+                // Split the buffer into rows
+                _currentBlock = _splitRows(block, _rowPositionArray);
+
+                // Stop at end-of-file (read didn't fill buffer)
+                if (bufferLengthFilled < _buffer.Length) break;
+
+                // Stop when a full row was read (split found at least two parts)
+                if (_currentBlock.Count > 1) break;
+
+                // Otherwise, double the buffer (until a full row or end of file)
+                byte[] newBuffer = new byte[_buffer.Length * 2];
+                _buffer.CopyTo(newBuffer, 0);
+                _buffer = newBuffer;
+            }
+
+            // If we read new content, reset the next row to read
+            if (bufferLengthFilled > bufferLengthFilledStart) _nextRowIndexInBlock = 0;
+        }
+
+        public void Dispose()
+        {
+            if (_stream != null)
+            {
+                _stream.Dispose();
+                _stream = null;
+            }
+        }
+    }
+}

--- a/Elfie/Elfie/Serialization/LDFTabularReader.cs
+++ b/Elfie/Elfie/Serialization/LDFTabularReader.cs
@@ -6,26 +6,31 @@ using System.IO;
 
 namespace Microsoft.CodeAnalysis.Elfie.Serialization
 {
+
+
     public class LdfTabularReader : ITabularReader
     {
+        private static String8 MultiValueDelimiter = String8.Convert("; ", new byte[2]);
+
         private Stream _stream;
 
         private String8Block _columnNamesBlock;
+        private Dictionary<String8, int> _columnIndices8;
         private Dictionary<string, int> _columnIndices;
         private List<string> _columnNames;
 
         private byte[] _buffer;
         private String8Set _blockLines;
         private PartialArray<int> _linePositionArray;
-        private int _nextRowFirstLine;
+        private int _nextRowFirstLineIndex;
+
+        private String8TabularValue[] _currentRowValues;
 
         public IReadOnlyList<string> Columns => _columnNames;
-
-        public int RowCountRead { get; private set; }
-
+        public int CurrentRowColumns => _columnNames.Count;
         public long BytesRead => _stream.Position;
 
-        public int CurrentRowColumns => throw new System.NotImplementedException();
+        public int RowCountRead { get; private set; }
 
         public LdfTabularReader(string filePath) : this(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
         { }
@@ -35,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
             _stream = stream;
 
             _columnNamesBlock = new String8Block();
+            _columnIndices8 = new Dictionary<String8, int>();
             _columnIndices = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             _columnNames = new List<string>();
 
@@ -42,6 +48,12 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
             _linePositionArray = new PartialArray<int>();
 
             ReadColumns();
+
+            _currentRowValues = new String8TabularValue[_columnNames.Count];
+            for(int i = 0; i < _currentRowValues.Length; ++i)
+            {
+                _currentRowValues[i] = new String8TabularValue();
+            }
         }
 
         #region ReadColumns
@@ -54,7 +66,6 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
             _columnNamesBlock = new String8Block();
 
             // Walk the whole LDF by line looking for every unique column name found
-            Dictionary<String8, int> columnsFound = new Dictionary<String8, int>();
             int lengthRead = _stream.Read(_buffer, 0, _buffer.Length);
 
             while (true)
@@ -63,25 +74,25 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
                 String8 block = new String8(_buffer, 0, lengthRead);
 
                 // Split the block into lines
-                String8Set lines = block.Split(UTF8.Newline, _linePositionArray);
+                _blockLines = block.Split(UTF8.Newline, _linePositionArray);
 
                 // Read and track all column names down to the second-to-last line
-                for (int i = 0; i < lines.Count - 1; ++i)
+                for (int i = 0; i < _blockLines.Count - 1; ++i)
                 {
-                    ReadColumnLine(lines[i], columnsFound);
+                    ReadColumnLine(_blockLines[i]);
                 }
 
-                String8 lastLine = lines[lines.Count - 1];
+                String8 lastLine = _blockLines[_blockLines.Count - 1];
 
                 // If we ran out of file, read the last line and stop
                 if (lengthRead < _buffer.Length)
                 {
-                    ReadColumnLine(lastLine, columnsFound);
+                    ReadColumnLine(lastLine);
                     break;
                 }
 
                 // If this was one big line, double the buffer to read more
-                if (lines.Count == 1)
+                if (_blockLines.Count == 1)
                 {
                     byte[] newBuffer = new byte[_buffer.Length * 2];
                     System.Buffer.BlockCopy(_buffer, 0, newBuffer, 0, _buffer.Length);
@@ -94,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
             }
         }
 
-        private void ReadColumnLine(String8 line, Dictionary<String8, int> columnsFound)
+        private void ReadColumnLine(String8 line)
         {
             // Skip empty and continuation lines
             if (line.Length == 0 || line[0] == UTF8.CR || line[0] == UTF8.Space) return;
@@ -103,48 +114,17 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
             String8 columnName = line.BeforeFirst(UTF8.Colon);
 
             // If we haven't seen this column name before, add it to our collection
-            if (!columnName.IsEmpty() && !columnsFound.ContainsKey(columnName))
+            if (!columnName.IsEmpty() && !_columnIndices8.ContainsKey(columnName))
             {
-                int columnIndex = columnsFound.Count;
-                columnsFound[_columnNamesBlock.GetCopy(columnName)] = columnIndex;
+                int columnIndex = _columnIndices8.Count;
+                _columnIndices8[_columnNamesBlock.GetCopy(columnName)] = columnIndex;
 
                 string columnNameString = columnName.ToString();
                 _columnNames.Add(columnNameString);
                 _columnIndices[columnNameString] = columnIndex;
             }
         }
-
         #endregion
-
-        protected String8Set Split(String8 block, PartialArray<int> rowPositionArray, PartialArray<int> cellPositionArray)
-        {
-            // Split every line
-            block.Split(UTF8.Newline, cellPositionArray);
-
-            // Identify row boundaries (a completely empty line [\n\n or \r\n\r\n] is a new 'row')
-            rowPositionArray.Clear();
-
-            for (int i = 1; i < cellPositionArray.Count; ++i)
-            {
-                int difference = cellPositionArray[i] - cellPositionArray[i - 1];
-
-                if (difference == 1)
-                {
-                    // \n\n is a row boundary
-                    rowPositionArray.Add(cellPositionArray[i]);
-                }
-                else if (difference == 2)
-                {
-                    // \n\r\n is a row boundary
-                    if (block[cellPositionArray[i] - 1] == UTF8.CR)
-                    {
-                        rowPositionArray.Add(cellPositionArray[i]);
-                    }
-                }
-            }
-
-            return new String8Set(block, 1, rowPositionArray);
-        }
 
         public bool TryGetColumnIndex(string columnNameOrIndex, out int columnIndex)
         {
@@ -157,13 +137,86 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
 
         public ITabularValue Current(int index)
         {
-            throw new System.NotImplementedException();
+            return _currentRowValues[index];
         }
 
         public bool NextRow()
         {
-            throw new System.NotImplementedException();
+            return false;
         }
+
+        //    // Clear values for row
+        //    for(int i = 0; i < _currentRowValues.Length; ++i)
+        //    {
+        //        _currentRowValues[i].SetValue(String8.Empty);
+        //    }
+
+        //    // Read available complete lines
+        //    String8 currentPropertyName = String8.Empty;
+        //    String8 currentPropertyValue = String8.Empty;
+
+        //    int currentLineIndex = _nextRowFirstLineIndex;
+        //    while (currentLineIndex < _blockLines.Count - 1)
+        //    {
+        //        String8 line = _blockLines[currentLineIndex];
+
+        //        // Trim trailing CR, if found
+        //        if (line.EndsWith(UTF8.CR)) line = line.Substring(0, line.Length - 1);
+
+        //        // An empty line means the end of this row
+        //        if (line.Length == 0)
+        //        {
+        //            // Set the last value
+        //            SetColumnValue(currentPropertyName, currentPropertyValue);
+
+        //            // Return that a row was found
+        //            return true;
+        //        }
+
+        //        // Look for a wrapped line
+        //        if (line[0] == UTF8.Space)
+        //        {
+        //            // If found, concatenate the value after the space onto the value so far
+        //            line = line.Substring(1);
+        //            Buffer.BlockCopy(_buffer, line._index, _buffer, currentPropertyValue._index + currentPropertyValue.Length, line.Length);
+        //            currentPropertyValue = new String8(_buffer, currentPropertyValue._index, currentPropertyValue._length + line.Length);
+        //        }
+        //        else
+        //        {
+        //            // Get the column name for this value
+        //            String8 columnName = line.BeforeFirst(UTF8.Colon);
+
+        //            // If it's the same as the previous one, concatenate the values
+        //            // ISSUE: Are multi-value base64 values possible?
+        //            if(currentColumnName.Equals(columnName))
+        //            {
+        //                line = line.Substring(columnName.Length + 2);
+
+        //                Buffer.BlockCopy(_buffer, line._index, _buffer, currentPropertyValue._index + currentPropertyValue.Length, line.Length);
+
+        //                currentPropertyValue = new String8(_buffer, currentPropertyValue._index, currentPropertyValue._length + line.Length);
+        //            }
+        //        }
+
+        //        currentLineIndex++;
+        //    }
+
+        //    int lengthRead = _stream.Read(_buffer, 0, _buffer.Length);
+        //    String8 block = new String8(_buffer, 0, lengthRead);
+        //    _blockLines = block.Split(UTF8.Newline, _linePositionArray);
+        //    _nextRowFirstLineIndex = 0;           
+        //}
+
+        //private void SetColumnValue(String8 currentPropertyName, String8 currentPropertyValue)
+        //{
+        //    // TODO: Unescape base64, translate SIDs, convert DateTimes
+        //    int columnIndex;
+        //    if(_columnIndices8.TryGetValue(currentPropertyName, out columnIndex))
+        //    {
+
+        //        _currentRowValues[columnIndex].SetValue(currentPropertyValue);
+        //    }
+        //}
 
         public void Dispose()
         {

--- a/Elfie/Elfie/Serialization/LDFTabularReader.cs
+++ b/Elfie/Elfie/Serialization/LDFTabularReader.cs
@@ -1,0 +1,220 @@
+﻿using Microsoft.CodeAnalysis.Elfie.Model.Strings;
+using Microsoft.CodeAnalysis.Elfie.Model.Structures;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.Elfie.Serialization
+{
+    public class LDFTabularReader : BaseTabularReader
+    {
+        private String8Block _columnNamesBlock;
+
+        private String8Set _blockLines;
+        private PartialArray<int> _linePositionArray;
+        private int _nextRowFirstLine;
+
+        public LDFTabularReader(string filePath) : this(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+        { }
+
+        public LDFTabularReader(Stream stream) : base(stream, false)
+        {
+            ReadColumns(stream);
+        }
+
+        private void ReadColumns(Stream stream)
+        {
+            // Allocate a fixed array to hold split lines
+            _linePositionArray = new PartialArray<int>(1024);
+
+            // Allocate a block to hold copies of unique column names
+            _columnNamesBlock = new String8Block();
+
+            // Walk the whole LDF by line looking for every unique column name found
+            Dictionary<String8, int> columnsFound = new Dictionary<String8, int>();
+            byte[] buffer = new byte[64 * 1024];
+            int lengthRead = stream.Read(buffer, 0, buffer.Length);
+
+            while(true)
+            {
+                // Read a block from the file
+                String8 block = new String8(buffer, 0, lengthRead);
+
+                // Split the block into lines
+                String8Set lines = block.Split(UTF8.Newline, _linePositionArray);
+
+                // Read and track all column names down to the second-to-last line
+                for(int i = 0; i < lines.Count - 1; ++i)
+                {
+                    ReadColumnLine(lines[i], columnsFound);
+                }
+
+                String8 lastLine = lines[lines.Count - 1];
+
+                // If we ran out of file, read the last line and stop
+                if (lengthRead < buffer.Length)
+                {
+                    ReadColumnLine(lastLine, columnsFound);
+                    break;
+                }
+
+                // If this was one big line, double the buffer to read more
+                if(lines.Count == 1)
+                {
+                    byte[] newBuffer = new byte[buffer.Length * 2];
+                    System.Buffer.BlockCopy(buffer, 0, newBuffer, 0, buffer.Length);
+                    buffer = newBuffer;
+                }
+
+                // Save the last line and read another block
+                System.Buffer.BlockCopy(buffer, 0, buffer, lastLine._index, lastLine.Length);
+                lengthRead = lastLine.Length + stream.Read(buffer, lastLine.Length, buffer.Length - lastLine.Length);
+            }
+        }
+
+        private void ReadColumnLine(String8 line, Dictionary<String8, int> columnsFound)
+        {
+            // Skip empty and continuation lines
+            if (line.Length == 0 || line[0] == UTF8.CR || line[0] == UTF8.Space) return;
+
+            // Find the column name part of the line
+            String8 columnName = line.BeforeFirst(UTF8.Colon);
+
+            // If we haven't seen this column name before, add it to our collection
+            if (!columnName.IsEmpty() && !columnsFound.ContainsKey(columnName))
+            {
+                int columnIndex = columnsFound.Count;
+                columnsFound[_columnNamesBlock.GetCopy(columnName)] = columnIndex;
+
+                string columnNameString = columnName.ToString();
+                _columnHeadingsList.Add(columnNameString);
+                _columnHeadings[columnNameString] = columnIndex;
+            }
+        }
+
+        protected String8Set Split(String8 block, PartialArray<int> rowPositionArray, PartialArray<int> cellPositionArray)
+        {
+            // Split every line
+            block.Split(UTF8.Newline, cellPositionArray);
+
+            // Identify row boundaries (a completely empty line [\n\n or \r\n\r\n] is a new 'row')
+            rowPositionArray.Clear();
+
+            for (int i = 1; i < cellPositionArray.Count; ++i)
+            {
+                int difference = cellPositionArray[i] - cellPositionArray[i - 1];
+
+                if (difference == 1)
+                {
+                    // \n\n is a row boundary
+                    rowPositionArray.Add(cellPositionArray[i]);
+                }
+                else if (difference == 2)
+                {
+                    // \n\r\n is a row boundary
+                    if (block[cellPositionArray[i] - 1] == UTF8.CR)
+                    {
+                        rowPositionArray.Add(cellPositionArray[i]);
+                    }
+                }
+            }
+
+            return new String8Set(block, 1, rowPositionArray);
+        }
+
+        protected override void SplitValues(String8Set rowCells, String8TabularValue[] rowValues)
+        {
+            base.SplitValues(rowCells, rowValues);
+        }
+
+        protected override String8Set SplitCells(String8 row, PartialArray<int> cellPositionArray)
+        {
+            // Identify cell boundaries (a line starting with space is a continuation of the previous value)
+            cellPositionArray.Clear();
+
+            int rowIndexInBlock = row._index - _blockReference._index;
+            int rowEndInBlock = rowIndexInBlock + row.Length;
+
+            //String8Set lines = new String8Set(_blockReference, 1, cellPositionArray);
+            //int currentLineIndex = _nextRowFirstLine;
+            //for (; currentLineIndex < lines.Count; ++currentLineIndex)
+            //{
+            //    String8 line = lines[currentLineIndex];
+
+            //    // If line is outside row, stop
+            //    if (line._index > rowEndInBlock) break;
+
+            //    switch(line[0])
+            //    {
+            //        case UTF8.Space:
+            //            // Multi-line attribute - unwrap
+            //            case UTF8
+            //    }
+            //}
+
+
+            // Walk lines after the last row identifying value boundaries (a line continues the previous value if it starts with space)
+            //int shiftBackAmount = 0;
+            int currentLineIndex = _nextRowFirstLine + 1;
+            for(; currentLineIndex < _linePositionArray.Count; ++currentLineIndex)
+            {
+                int lineStartIndex = _linePositionArray[currentLineIndex];
+
+                // If this line is after the row, stop
+                if (lineStartIndex >= rowEndInBlock) break;
+
+                // If the line starts with a space, shift it back to make it contiguous
+                if (_blockReference[lineStartIndex] != UTF8.Space)
+                {
+                    // Convert the block index to a row-relative index
+                    cellPositionArray.Add(lineStartIndex - rowIndexInBlock);
+                }
+                //else
+                //{
+                //    shiftBackAmount += 2;
+                //    if (_blockReference[lineStartIndex - 2] == UTF8.CR) shiftBackAmount++;
+
+                //    _blockReference.Substring(lineStartIndex, _linePositionArray[currentLineIndex + 1] - lineStartIndex).ShiftBack(shiftBackAmount);
+                //}
+            }
+
+            // Track the line which starts the next row
+            _nextRowFirstLine = currentLineIndex;
+
+            return new String8Set(row, 1, cellPositionArray);
+        }
+
+        protected override String8Set SplitRows(String8 block, PartialArray<int> rowPositionArray)
+        {
+            // LDF files are line-based. We want to split the entire block on newlines and then
+            // reconstruct the logical row and cell boundaries by looking at the lines.
+
+            // Split the entire block into lines
+            _blockLines = block.Split(UTF8.Newline, _linePositionArray);
+
+            // Track lines read so far, so each row and cell read can process by line
+            _nextRowFirstLine = 0;
+
+            // Identify row boundaries (a completely empty line [\n\n or \r\n\r\n] is a new 'row')
+            rowPositionArray.Clear();
+            rowPositionArray.Add(0);
+
+            for (int i = 0; i < _blockLines.Count; ++i)
+            {
+                String8 line = _blockLines[i];
+
+                if(line.Length == 0)
+                {
+                    // \n\n is a row boundary
+                    rowPositionArray.Add(_linePositionArray[i]);
+                }
+                else if (line.Length == 1 && line[0] == UTF8.CR)
+                {
+                    // \n\r\n is a row boundary
+                    rowPositionArray.Add(_linePositionArray[i]);
+                }
+            }
+
+            return new String8Set(block, 1, rowPositionArray);
+        }
+    }
+}

--- a/Elfie/Elfie/Serialization/TabularFactory.cs
+++ b/Elfie/Elfie/Serialization/TabularFactory.cs
@@ -26,6 +26,8 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
             s_readers["tsv"] = (path) => new TsvReader(path);
             s_readers["tsvNH"] = (path) => new TsvReader(MapExtension(path, ".tsv"), false);
             s_readers["iislog"] = (path) => new IISTabularReader(MapExtension(path, ".log"));
+            s_readers["ldf"] = (path) => new LdfTabularReader(path);
+            s_readers["ldif"] = (path) => new LdfTabularReader(path);
 
             s_writers["cout"] = (path) => new ConsoleTabularWriter();
             s_writers["csv"] = (path) => new CsvWriter(path, true);


### PR DESCRIPTION
- String8: Fill in StartsWith and EndsWith for String8 and byte.
- String8: Add TrimEnd.
- String8: Add TryToDateTimeExact to parse other DateTime formats.
- String8: Generic number parsing to allow TryToLong, TryToUInt, TryToULong.

- Add LdfTabularReader for LDIF format (Active Directory export).
- Factor BaseTabularReader buffered reading into BufferedRowReader.