### PR TITLE
Arriba and XForm fixes for shim work.

### DIFF
--- a/Arriba/Arriba.Communication/Server/Application/ArribaQueryApplication.cs
+++ b/Arriba/Arriba.Communication/Server/Application/ArribaQueryApplication.cs
@@ -381,38 +381,6 @@ namespace Arriba.Server
             return ArribaResponse.Ok(result);
         }
 
-        private class AllCountResult
-        {
-            public string Query { get; set; }
-            public string ParsedQuery { get; set; }
-
-            public List<CountResult> ResultsPerTable { get; set; }
-
-            public AllCountResult(string query)
-            {
-                this.Query = query;
-                this.ParsedQuery = QueryParser.Parse(query).ToString();
-
-                this.ResultsPerTable = new List<CountResult>();
-            }
-        }
-
-        private class CountResult
-        {
-            public string TableName { get; set; }
-            public ulong Count { get; set; }
-            public bool AllowedToRead { get; set; }
-            public bool Succeeded { get; set; }
-
-            public CountResult(string tableName, ulong count, bool allowedToRead, bool succeeded)
-            {
-                this.TableName = tableName;
-                this.Count = count;
-                this.AllowedToRead = allowedToRead;
-                this.Succeeded = succeeded;
-            }
-        }
-
         private async Task<IResponse> Suggest(IRequestContext ctx, Route route)
         {
             NameValueCollection p = await ParametersFromQueryStringAndBody(ctx);

--- a/Arriba/Arriba/Arriba.csproj
+++ b/Arriba/Arriba/Arriba.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Model\Column\ColumnDetails.cs" />
     <Compile Include="Model\Column\FastAddSortedColumn.cs" />
     <Compile Include="Model\Column\IpRangeColumn.cs" />
+    <Compile Include="Model\Query\AllCountResult.cs" />
     <Compile Include="Model\Query\DistributionQuery.cs" />
     <Compile Include="Model\Query\PercentilesQuery.cs" />
     <Compile Include="Model\Query\TermInColumnsQuery.cs" />

--- a/Arriba/Arriba/Model/Column/ColumnFactory.cs
+++ b/Arriba/Arriba/Model/Column/ColumnFactory.cs
@@ -41,6 +41,7 @@ namespace Arriba
             s_columnCreators["boolean"] = s_columnCreators["bool"];
 
             s_columnCreators["byte"] = (details, columnComponents, initialCapacity) => { AdjustColumnComponents(ref columnComponents); return Build<byte>(details, columnComponents, initialCapacity); };
+            s_columnCreators["sbyte"] = (details, columnComponents, initialCapacity) => { AdjustColumnComponents(ref columnComponents); return Build<sbyte>(details, columnComponents, initialCapacity); };
 
             s_columnCreators["short"] = (details, columnComponents, initialCapacity) => { AdjustColumnComponents(ref columnComponents); return Build<short>(details, columnComponents, initialCapacity); };
             s_columnCreators["int16"] = s_columnCreators["short"];

--- a/Arriba/Arriba/Model/Query/AllCountResult.cs
+++ b/Arriba/Arriba/Model/Query/AllCountResult.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+
+namespace Arriba.Model.Query
+{
+    public class AllCountResult
+    {
+        public string Query { get; set; }
+        public string ParsedQuery { get; set; }
+
+        public List<CountResult> ResultsPerTable { get; set; }
+
+        public AllCountResult(string query)
+        {
+            this.Query = query;
+            this.ParsedQuery = QueryParser.Parse(query).ToString();
+
+            this.ResultsPerTable = new List<CountResult>();
+        }
+    }
+
+    public class CountResult
+    {
+        public string TableName { get; set; }
+        public ulong Count { get; set; }
+        public bool AllowedToRead { get; set; }
+        public bool Succeeded { get; set; }
+
+        public CountResult(string tableName, ulong count, bool allowedToRead, bool succeeded)
+        {
+            this.TableName = tableName;
+            this.Count = count;
+            this.AllowedToRead = allowedToRead;
+            this.Succeeded = succeeded;
+        }
+    }
+
+}

--- a/Arriba/Arriba/Model/Query/QueryIntelliSense.cs
+++ b/Arriba/Arriba/Model/Query/QueryIntelliSense.cs
@@ -369,7 +369,7 @@ namespace Arriba.Model.Query
             return result;
         }
 
-        private static IReadOnlyCollection<Table> FilterToValidTablesForQuery(IReadOnlyCollection<Table> tables, string query)
+        public static IReadOnlyCollection<Table> FilterToValidTablesForQuery(IReadOnlyCollection<Table> tables, string query)
         {
             // Parse the query to execute (exclude incomplete terms)
             IExpression queryToExecute = QueryParser.Parse(query);

--- a/XForm/XForm/Http/BackgroundWebServer.cs
+++ b/XForm/XForm/Http/BackgroundWebServer.cs
@@ -29,13 +29,15 @@ namespace XForm
         private HttpListener Listener { get; set; }
         private Thread ListenerThread { get; set; }
 
+        private ushort PortNumber { get; set; }
         private string DefaultDocument { get; set; }
         private Dictionary<string, Action<IHttpRequest, IHttpResponse>> MethodsToServe { get; set; }
         private Dictionary<string, string> FilesToServe { get; set; }
         private string FolderToServe { get; set; }
 
-        public BackgroundWebServer(string defaultDocument, string serveUnderRelativePath)
+        public BackgroundWebServer(ushort portNumber, string defaultDocument, string serveUnderRelativePath)
         {
+            this.PortNumber = portNumber;
             this.IsRunning = false;
 
             this.DefaultDocument = defaultDocument;
@@ -75,10 +77,10 @@ namespace XForm
             this.Stop();
         }
 
-        private void StartForBinding(params string[] urls)
+        private void StartForBinding(bool withAuthentication, params string[] urls)
         {
             this.Listener = new HttpListener();
-            this.Listener.AuthenticationSchemes = AuthenticationSchemes.Negotiate;
+            if (withAuthentication) this.Listener.AuthenticationSchemes = AuthenticationSchemes.Negotiate;
 
             foreach (string url in urls)
             {
@@ -94,9 +96,9 @@ namespace XForm
             {
                 try
                 {
-                    // Try binding for all names on port 5073
-                    StartForBinding("http://+:5073/");
-                    Console.WriteLine("Web Server running; browse to http://localhost:5073. [Local and Remote]\r\nPress enter to stop server.");
+                    // Try binding for all names on port
+                    StartForBinding(true, $"http://+:{PortNumber}/");
+                    Console.WriteLine($"Web Server running; browse to http://localhost:{PortNumber}. [Local and Remote]\r\nPress enter to stop server.");
                 }
                 catch (HttpListenerException ex) when (ex.ErrorCode == 5)
                 {
@@ -106,9 +108,9 @@ namespace XForm
 
                 if (this.Listener == null)
                 {
-                    // Try binding to just localhost:5073
-                    StartForBinding("http://localhost:5073/");
-                    Console.WriteLine("Web Server running; browse to http://localhost:5073. [Local Only]");
+                    // Try binding to just localhost
+                    StartForBinding(false, $"http://localhost:{PortNumber}/");
+                    Console.WriteLine($"Web Server running; browse to http://localhost:{PortNumber}. [Local Only]");
                     Console.WriteLine(" To enable remote: https://github.com/Microsoft/elfie-arriba/wiki/XForm-Http-Remote-Access");
                     Console.WriteLine("Press enter to stop server.");
                 }
@@ -217,15 +219,24 @@ namespace XForm
         private bool ReturnMethodItem(string requestUri, IHttpRequest request, IHttpResponse response)
         {
             Action<IHttpRequest, IHttpResponse> writeMethod;
-            if (this.MethodsToServe.TryGetValue(requestUri, out writeMethod))
-            {
-                response.AddHeader("Cache-Control", "no-cache, no-store");
-                response.ContentType = ContentType(requestUri);
-                response.StatusCode = 200;
 
-                writeMethod(request, response);
-                response.Close();
-                return true;
+            while (true)
+            {
+                // Look for a handler for the passed URI
+                if (this.MethodsToServe.TryGetValue(requestUri, out writeMethod))
+                {
+                    response.AddHeader("Cache-Control", "no-cache, no-store");
+                    response.StatusCode = 200;
+
+                    writeMethod(request, response);
+                    response.Close();
+                    return true;
+                }
+
+                // If not found, look for handlers for prefixes of the URI (which will route)
+                int lastSlash = requestUri.LastIndexOf('/');
+                if (lastSlash == -1) break;
+                requestUri = requestUri.Substring(0, lastSlash);
             }
 
             return false;

--- a/XForm/XForm/HttpService.cs
+++ b/XForm/XForm/HttpService.cs
@@ -29,7 +29,7 @@ namespace XForm
             _xDatabaseContext = xDatabaseContext;
             _suggester = new QuerySuggester(_xDatabaseContext);
 
-            _server = new BackgroundWebServer("index.html", "Web");
+            _server = new BackgroundWebServer(5073, "index.html", "Web");
             _server.AddResponder("suggest", Suggest);
             _server.AddResponder("run", Run);
             _server.AddResponder("download", Download);

--- a/XForm/XForm/XForm.csproj
+++ b/XForm/XForm/XForm.csproj
@@ -236,6 +236,6 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)\Deploy.WebSite.cmd $(TargetDir)</PostBuildEvent>
+    <PostBuildEvent>$(ProjectDir)\..\Deploy.WebSite.cmd $(TargetDir)</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
  - Add "sbyte" support in Arriba.
  - Make AllCountResult and CountResult types public and move to Arriba.dll.
  - Expose QueryIntelliSense.FilterToValidTablesForQuery for shim suggest.
  - XForm: Make server port configurable.
  - XForm: ReturnMethodItem will invoke any path prefix of URL (allowing routing)