### PR TITLE
Percentage Output Fix

### DIFF
--- a/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
+++ b/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
@@ -264,6 +264,11 @@ namespace Arriba.Test.Model.Query
             Assert.AreEqual("AND, [Age]", string.Join(", ", result.Suggestions.Select(ii => ii.Display)));
         }
 
+        private string ToPercent(double value)
+        {
+            return value.ToString("P0");
+        }
+
         [TestMethod]
         public void QueryIntelliSense_InlineInsights()
         {
@@ -280,25 +285,25 @@ namespace Arriba.Test.Model.Query
 
             // Values are suggested in order by frequency
             result = qi.GetIntelliSenseItems("[Student Count] = ", Tables);
-            Assert.AreEqual("100000 70%, 10000 20%, 1000 10%", ItemsAndCounts(result));
+            Assert.AreEqual($"100000 {ToPercent(.7)}, 10000 {ToPercent(.2)}, 1000 {ToPercent(.1)}", ItemsAndCounts(result));
 
             // Values are filtered according to the query
             result = qi.GetIntelliSenseItems("[ID] < 15 AND [Student Count] = ", Tables);
-            Assert.AreEqual("1000 67%, 10000 33%", ItemsAndCounts(result));
+            Assert.AreEqual($"1000 {ToPercent(.67)}, 10000 {ToPercent(.33)}", ItemsAndCounts(result));
 
             // Distributions are returned for range operators
             // Only non-empty buckets are returned.
             result = qi.GetIntelliSenseItems("[Student Count] < ", Tables);
-            Assert.AreEqual("17500 30%", ItemsAndCounts(result));
+            Assert.AreEqual($"17500 {ToPercent(.3)}", ItemsAndCounts(result));
 
             result = qi.GetIntelliSenseItems("[Student Count] <= ", Tables);
-            Assert.AreEqual("1000 10%, 17500 30%, 100000 all", ItemsAndCounts(result));
+            Assert.AreEqual($"1000 {ToPercent(.1)}, 17500 {ToPercent(.3)}, 100000 all", ItemsAndCounts(result));
 
             result = qi.GetIntelliSenseItems("[Student Count] > ", Tables);
-            Assert.AreEqual("83500 70%, 1000 90%", ItemsAndCounts(result));
+            Assert.AreEqual($"83500 {ToPercent(.7)}, 1000 {ToPercent(.9)}", ItemsAndCounts(result));
 
             result = qi.GetIntelliSenseItems("[Student Count] >= ", Tables);
-            Assert.AreEqual("100000 70%, 1000 all", ItemsAndCounts(result));
+            Assert.AreEqual($"100000 {ToPercent(.7)}, 1000 all", ItemsAndCounts(result));
 
             // Only show one value when there's only one value available
             result = qi.GetIntelliSenseItems("[ID] > 50 AND [Student Count] >= ", Tables);
@@ -310,7 +315,7 @@ namespace Arriba.Test.Model.Query
 
             // Works for TimeSpan
             result = qi.GetIntelliSenseItems("[SchoolYearLength] >= ", Tables);
-            Assert.AreEqual("211.00:00:00 12%, 208.00:00:00 21%, 204.00:00:00 33%, 200.00:00:00 45%, 196.00:00:00 57%, 192.00:00:00 72%, 188.00:00:00 88%", ItemsAndCounts(result));
+            Assert.AreEqual($"211.00:00:00 {ToPercent(.12)}, 208.00:00:00 {ToPercent(.21)}, 204.00:00:00 {ToPercent(.33)}, 200.00:00:00 {ToPercent(.45)}, 196.00:00:00 {ToPercent(.57)}, 192.00:00:00 {ToPercent(.72)}, 188.00:00:00 {ToPercent(.88)}", ItemsAndCounts(result));
 
             // Works for DateTime
             result = qi.GetIntelliSenseItems("[WhenFounded] >= ", Tables);
@@ -322,15 +327,15 @@ namespace Arriba.Test.Model.Query
 
             // Term column suggestions are offered
             result = qi.GetIntelliSenseItems("Uni", Tables);
-            Assert.AreEqual("[Name] : Uni 40%, [Mascot] : Uni 25%", ItemsAndCounts(result));
+            Assert.AreEqual($"[Name] : Uni {ToPercent(.40)}, [Mascot] : Uni {ToPercent(.25)}", ItemsAndCounts(result));
 
             // Term column suggestions are based on the remaining query rows
             result = qi.GetIntelliSenseItems("[Mascot] : Uni AND Uni", Tables);
-            Assert.AreEqual("[Mascot] : Uni all, [Name] : Uni 40%", ItemsAndCounts(result));
+            Assert.AreEqual($"[Mascot] : Uni all, [Name] : Uni {ToPercent(.40)}", ItemsAndCounts(result));
 
             // Term suggestions only show for columns which have any matches
             result = qi.GetIntelliSenseItems("Ele", Tables);
-            Assert.AreEqual("[Mascot] : Ele 25%", ItemsAndCounts(result));
+            Assert.AreEqual($"[Mascot] : Ele {ToPercent(.25)}", ItemsAndCounts(result));
 
             // Term suggestions only show if the term has matches
             result = qi.GetIntelliSenseItems("Elelion", Tables);

--- a/XForm/XForm.Test/Verbs/VerbsTests.cs
+++ b/XForm/XForm.Test/Verbs/VerbsTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 using Microsoft.CodeAnalysis.Elfie.Model.Strings;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
+using XForm.Aggregators;
 using XForm.Data;
 using XForm.Extensions;
 using XForm.Verbs;
@@ -139,6 +139,11 @@ namespace XForm.Test.Query
             TableTestHarness.AssertAreEqual(expected, actual, 2);
         }
 
+        private string ToPercent(double value)
+        {
+            return value.ToString("P0");
+        }
+
         [TestMethod]
         public void Verb_Peek()
         {
@@ -148,7 +153,12 @@ namespace XForm.Test.Query
             IXTable expected = TableTestHarness.DatabaseContext.FromArrays(3)
                 .WithColumn("Value", new int[] { 0, 1, 2 })
                 .WithColumn("Count", new int[] { 500, 250, 150 })
-                .WithColumn("Percentage", TableTestHarness.ToString8(new string[] { "50%", "25%", "15%" }));
+                .WithColumn("Percentage", TableTestHarness.ToString8(new string[]
+                {
+                    PercentageAggregator.TwoSigFigs(500, 1000),
+                    PercentageAggregator.TwoSigFigs(250, 1000),
+                    PercentageAggregator.TwoSigFigs(150, 1000)
+                }));
 
             IXTable actual = TableTestHarness.DatabaseContext.FromArrays(values.Length)
                 .WithColumn("Value", values)
@@ -166,7 +176,12 @@ namespace XForm.Test.Query
             IXTable expected = TableTestHarness.DatabaseContext.FromArrays(3)
                 .WithColumn("Value", new int[] { 0, 1, 2 })
                 .WithColumn("Count", new int[] { 500, 250, 150 })
-                .WithColumn("Percentage", TableTestHarness.ToString8(new string[] { "50.0%", "25.0%", "15.0%" }));
+                .WithColumn("Percentage", TableTestHarness.ToString8(new string[] 
+                {
+                    PercentageAggregator.ThreeSigFigs(500, 1000),
+                    PercentageAggregator.ThreeSigFigs(250, 1000),
+                    PercentageAggregator.ThreeSigFigs(150, 1000)
+                }));
 
             IXTable actual = TableTestHarness.DatabaseContext.FromArrays(values.Length)
                 .WithColumn("Value", values)


### PR DESCRIPTION
Using toString methods to generate percents.  This fixes and issue where the expected output for percent strings differs between dev machines and build servers.