### PR TITLE
XForm Partition Support

### DIFF
--- a/XForm/XForm.Test/AssertCommand.cs
+++ b/XForm/XForm.Test/AssertCommand.cs
@@ -57,7 +57,7 @@ namespace XForm.Test
                 _sourceRowsTotal += count;
 
                 // Make the asserts run and count matching rows
-                _assertRowsTotal += _assertPipeline.RunWithoutDispose();
+                _assertRowsTotal += _assertPipeline.Count();
             }
             else
             {
@@ -121,18 +121,18 @@ namespace XForm.Test
     {
         public string TableName { get; private set; }
         public string Query { get; private set; }
-        public int QueryLineNumber { get; private set; }
+        public Position Position { get; private set; }
 
         public QueryDebuggingContext(XDatabaseContext context)
         {
             this.TableName = context.CurrentTable;
             this.Query = context.CurrentQuery;
-            this.QueryLineNumber = context.Parser.CurrentLineNumber;
+            this.Position = context.Parser.CurrentPosition;
         }
 
         public override string ToString()
         {
-            return $"Building {TableName}, line {QueryLineNumber}.\r\nTo Debug:\r\n{Query}";
+            return $"Building {TableName}, @{Position}.\r\nTo Debug:\r\n{Query}";
         }
     }
 }

--- a/XForm/XForm.Test/Query/SuggestTests.cs
+++ b/XForm/XForm.Test/Query/SuggestTests.cs
@@ -169,8 +169,12 @@ namespace XForm.Test.Query
 
         private static string Values(SuggestResult result)
         {
-            if (result.Context == null || result.Context.ValidValues == null) return null;
-            return string.Join("|", result.Context.ValidValues.OrderBy((s) => s));
+            if (result.Context == null) return null;
+
+            var values = result.Context.FilteredValues;
+            if (values == null) return null;
+
+            return string.Join("|", result.Context.FilteredValues);
         }
     }
 }

--- a/XForm/XForm.Test/Query/SuggestTests.cs
+++ b/XForm/XForm.Test/Query/SuggestTests.cs
@@ -37,23 +37,26 @@ namespace XForm.Test.Query
 
             // Verbs
             Assert.AreEqual(s_verbs, Values(suggester.Suggest("")));
-            Assert.AreEqual(string.Join("|", XqlParser.SupportedVerbs.Where((s) => s.StartsWith("re", System.StringComparison.OrdinalIgnoreCase)).OrderBy((s) => s)), Values(suggester.Suggest("re")));
+            Assert.AreEqual(string.Join("|", XqlParser.SupportedVerbs.Where((s) => s.IndexOf("re", System.StringComparison.OrdinalIgnoreCase) != -1).OrderBy((s) => s)), Values(suggester.Suggest("re")));
 
-            // Valid
-            Assert.AreEqual(null, Values(suggester.Suggest("read")));
+            // Valid, other values available
+            Assert.AreEqual("read|readrange", Values(suggester.Suggest("read")));
 
             // Tables
             Assert.AreEqual(s_sources, Values(suggester.Suggest("read ")));
 
-            // Valid
-            Assert.AreEqual(null, Values(suggester.Suggest($"read WebRequest")));
+            // Tables, filtered 
+            Assert.AreEqual("WebRequest.BigServers|WebRequest.BigServers.Direct", Values(suggester.Suggest($"read Request.Big")));
+
+            // Valid, no alternatives
+            Assert.AreEqual(null, Values(suggester.Suggest($"read WebRequest.NullableHandling")));
 
             // Verbs (newline)
             Assert.AreEqual(s_verbs, Values(suggester.Suggest($"read WebRequest\r\n")));
             Assert.AreEqual(s_verbs, Values(suggester.Suggest($"read WebRequest\r\n ")));
 
             // Valid
-            Assert.AreEqual(null, Values(suggester.Suggest($@"
+            Assert.AreEqual("!=|:|::||>|<|<=|<>|=|==|>|>=", Values(suggester.Suggest($@"
                 read WebRequest
                 where [HttpStatus]")));
 
@@ -112,7 +115,7 @@ namespace XForm.Test.Query
                 select Trim(Cast(Cast(5, Int32), String8)) AS [Fiver]").IsValid);
 
             // Valid
-            Assert.AreEqual(null, Values(suggester.Suggest($@"
+            Assert.AreEqual(s_selectListOptions, Values(suggester.Suggest($@"
                 read WebRequest
                 select [HttpStatus]")));
 
@@ -161,7 +164,7 @@ namespace XForm.Test.Query
             Assert.AreEqual("where {Expression}", result.Context.Usage);
             Assert.AreEqual("[BadColumnName]", result.Context.InvalidValue);
             Assert.AreEqual("[Column]", result.Context.InvalidValueCategory);
-            Assert.AreEqual("", string.Join("|", result.Context.ValidValues));
+            Assert.AreEqual("[ClientBrowser]|[ClientIP]|[ClientOs]|[ClientRegion]|[DataCenter]|[DaysSinceJoined]|[EventTime]|[HttpMethod]|[HttpStatus]|[ID]|[IsPremiumUser]|[Protocol]|[RequestBytes]|[ResponseBytes]|[ServerName]|[ServerPort]|[TimeTakenMs]|[UriStem]|[UserGuid]|[UserName]|[WasCachedResponse]|[WasEncrypted]", string.Join("|", result.Context.ValidValues));
         }
 
         private static string Values(SuggestResult result)

--- a/XForm/XForm.Test/Query/XTableBasicTests.cs
+++ b/XForm/XForm.Test/Query/XTableBasicTests.cs
@@ -36,13 +36,13 @@ namespace XForm.Test.Query
                     pipeline = SampleDatabase.XDatabaseContext.Query(configurationLine, innerValidator);
 
                     // Run without requesting any columns. Validate.
-                    actualRowCount = pipeline.RunWithoutDispose(token);
+                    actualRowCount = pipeline.Count(token);
                     Assert.AreEqual(expectedRowCount, actualRowCount, "XTable should return correct count with no requested columns.");
 
                     // Reset; Request all columns. Validate.
                     pipeline.Reset();
                     pipeline = SampleDatabase.XDatabaseContext.Query("write \"Sample.output.csv\"", pipeline);
-                    actualRowCount = pipeline.RunWithoutDispose(token);
+                    actualRowCount = pipeline.Count(token);
                 }
                 finally
                 {

--- a/XForm/XForm.Test/Query/XTableBasicTests.cs
+++ b/XForm/XForm.Test/Query/XTableBasicTests.cs
@@ -36,13 +36,13 @@ namespace XForm.Test.Query
                     pipeline = SampleDatabase.XDatabaseContext.Query(configurationLine, innerValidator);
 
                     // Run without requesting any columns. Validate.
-                    actualRowCount = pipeline.Count(token);
+                    actualRowCount = pipeline.RunWithoutDispose(token).RowCount;
                     Assert.AreEqual(expectedRowCount, actualRowCount, "XTable should return correct count with no requested columns.");
 
                     // Reset; Request all columns. Validate.
                     pipeline.Reset();
                     pipeline = SampleDatabase.XDatabaseContext.Query("write \"Sample.output.csv\"", pipeline);
-                    actualRowCount = pipeline.Count(token);
+                    actualRowCount = pipeline.RunWithoutDispose(token).RowCount;
                 }
                 finally
                 {

--- a/XForm/XForm.Test/Query/XqlParsingTests.cs
+++ b/XForm/XForm.Test/Query/XqlParsingTests.cs
@@ -135,7 +135,7 @@ namespace XForm.Test.Query
         private static int RunAndCount(string query, IXTable source, XDatabaseContext context)
         {
             source.Reset();
-            return (int)context.Query(query, source).Count();
+            return (int)context.Query(query, source).RunWithoutDispose().RowCount;
         }
 
         [TestMethod]

--- a/XForm/XForm.Test/Query/XqlParsingTests.cs
+++ b/XForm/XForm.Test/Query/XqlParsingTests.cs
@@ -135,7 +135,7 @@ namespace XForm.Test.Query
         private static int RunAndCount(string query, IXTable source, XDatabaseContext context)
         {
             source.Reset();
-            return (int)context.Query(query, source).RunWithoutDispose();
+            return (int)context.Query(query, source).Count();
         }
 
         [TestMethod]

--- a/XForm/XForm.Test/SampleDatabase.cs
+++ b/XForm/XForm.Test/SampleDatabase.cs
@@ -118,7 +118,7 @@ namespace XForm.Test
                 set [ClientOsUpper] Trim(ToUpper([ClientOs]))
                 set [Sample] ToUpper(Trim(""  Sample  ""))
                 assert none
-                    where [Sample] != ""SAMPLE""").RunAndDispose();
+                    where [Sample] != ""SAMPLE""").Count();
         }
 
         [TestMethod]
@@ -195,19 +195,19 @@ namespace XForm.Test
 
             // Asking for 2d from 2017-12-04 should get 2017-12-03 and 2017-12-02 crawls
             XDatabaseContext historicalContext = new XDatabaseContext(SampleDatabase.XDatabaseContext) { RequestedAsOfDateTime = new DateTime(2017, 12, 04, 00, 00, 00, DateTimeKind.Utc) };
-            Assert.AreEqual(2000, historicalContext.Query("readRange 2d WebRequest").RunAndDispose());
+            Assert.AreEqual(2000, historicalContext.Query("readRange 2d WebRequest").Count());
 
             // Asking for 3d should get all three crawls
-            Assert.AreEqual(3000, historicalContext.Query("readRange 3d WebRequest").RunAndDispose());
+            Assert.AreEqual(3000, historicalContext.Query("readRange 3d WebRequest").Count());
 
             // Asking for 4d should get all three crawls (allowed to ask for beyond first version)
-            Assert.AreEqual(3000, historicalContext.Query("readRange 4d WebRequest").RunAndDispose());
+            Assert.AreEqual(3000, historicalContext.Query("readRange 4d WebRequest").Count());
 
             // Asking for unknown table should error
-            Verify.Exception<UsageException>(() => historicalContext.Query("readRange 4d WebRequester").RunAndDispose());
+            Verify.Exception<UsageException>(() => historicalContext.Query("readRange 4d WebRequester").Count());
 
             // Asking for negative TimeSpan should error
-            Verify.Exception<UsageException>(() => historicalContext.Query("readRange -4d WebRequest").RunAndDispose());
+            Verify.Exception<UsageException>(() => historicalContext.Query("readRange -4d WebRequest").Count());
         }
 
         [TestMethod]
@@ -284,19 +284,19 @@ namespace XForm.Test
             // Build WebServer as of 2017-11-25; should have 86 original rows, verify built copy cached
             reportContext.NewestDependency = DateTime.MinValue;
             reportContext.RequestedAsOfDateTime = new DateTime(2017, 11, 25, 00, 00, 00, DateTimeKind.Utc);
-            Assert.AreEqual(86, SampleDatabase.XDatabaseContext.Runner.Build("WebServer", reportContext).RunAndDispose());
+            Assert.AreEqual(86, SampleDatabase.XDatabaseContext.Runner.Build("WebServer", reportContext).Count());
             Assert.AreEqual(new DateTime(2017, 11, 25, 00, 00, 00, DateTimeKind.Utc), SampleDatabase.XDatabaseContext.StreamProvider.ItemVersions(LocationType.Table, "WebServer").LatestBeforeCutoff(CrawlType.Full, DateTime.UtcNow).AsOfDate);
 
             // Build WebServer as of 2017-11-27; should have 91 rows (one incremental added)
             reportContext.NewestDependency = DateTime.MinValue;
             reportContext.RequestedAsOfDateTime = new DateTime(2017, 11, 27, 00, 00, 00, DateTimeKind.Utc);
-            Assert.AreEqual(91, SampleDatabase.XDatabaseContext.Runner.Build("WebServer", reportContext).RunAndDispose());
+            Assert.AreEqual(91, SampleDatabase.XDatabaseContext.Runner.Build("WebServer", reportContext).Count());
             Assert.AreEqual(new DateTime(2017, 11, 27, 00, 00, 00, DateTimeKind.Utc), SampleDatabase.XDatabaseContext.StreamProvider.ItemVersions(LocationType.Table, "WebServer").LatestBeforeCutoff(CrawlType.Full, DateTime.UtcNow).AsOfDate);
 
             // Build WebServer as of 2017-11-29; should have 96 rows (two incrementals added)
             reportContext.NewestDependency = DateTime.MinValue;
             reportContext.RequestedAsOfDateTime = new DateTime(2017, 11, 29, 00, 00, 00, DateTimeKind.Utc);
-            Assert.AreEqual(96, SampleDatabase.XDatabaseContext.Runner.Build("WebServer", reportContext).RunAndDispose());
+            Assert.AreEqual(96, SampleDatabase.XDatabaseContext.Runner.Build("WebServer", reportContext).Count());
             Assert.AreEqual(new DateTime(2017, 11, 29, 00, 00, 00, DateTimeKind.Utc), SampleDatabase.XDatabaseContext.StreamProvider.ItemVersions(LocationType.Table, "WebServer").LatestBeforeCutoff(CrawlType.Full, DateTime.UtcNow).AsOfDate);
         }
 
@@ -323,7 +323,7 @@ namespace XForm.Test
             //XForm("build WebRequest");
 
             // To debug engine execution, run like this:
-            XqlParser.Parse("read webrequest", null, SampleDatabase.XDatabaseContext).RunAndDispose();
+            XqlParser.Parse("read webrequest", null, SampleDatabase.XDatabaseContext).Count();
         }
 
         [TestMethod]
@@ -336,20 +336,20 @@ namespace XForm.Test
             // Verify table and column name accesses work case insensitive
             Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query(@"
                 read webrequest
-                select [id]").RunAndDispose());
+                select [id]").Count());
 
             // Verify Equals is case sensitive but contains isn't
             Assert.AreEqual((long)916, SampleDatabase.XDatabaseContext.Query(@"
                 read webrequest
-                where [HttpMethod] = ""GET""").RunAndDispose());
+                where [HttpMethod] = ""GET""").Count());
 
             Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query(@"
                 read webrequest
-                where [HttpMethod] = ""get""").RunAndDispose());
+                where [HttpMethod] = ""get""").Count());
 
             Assert.AreEqual((long)916, SampleDatabase.XDatabaseContext.Query(@"
                 read webrequest
-                where [HttpMethod] : ""get""").RunAndDispose());
+                where [HttpMethod] : ""get""").Count());
         }
 
         private static int ExpectedResult(string sourceName)
@@ -365,7 +365,7 @@ namespace XForm.Test
             // Exercise paging over rows in a complex case.
             //  'choose' will cause two passes of where; where must resume after reset correctly.
             //  'limit' asks for partial rows, forcing paging to occur.
-            Assert.AreEqual(5, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]: \"Edge\"\r\nchoose Max [ResponseBytes] [ClientOs]\r\nlimit 5").RunAndDispose());
+            Assert.AreEqual(5, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]: \"Edge\"\r\nchoose Max [ResponseBytes] [ClientOs]\r\nlimit 5").Count());
         }
     }
 }

--- a/XForm/XForm.Test/Verbs/WhereTests.cs
+++ b/XForm/XForm.Test/Verbs/WhereTests.cs
@@ -1,5 +1,9 @@
-﻿using Elfie.Test;
+﻿using System;
+
+using Elfie.Test;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using XForm.Extensions;
 using XForm.Query;
 
@@ -172,6 +176,14 @@ namespace XForm.Test.Verbs
 
             // Where invalid after cast (error)
             Verify.Exception<UsageException>(() => SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) != \"invalid\"").RunAndDispose());
+        }
+
+        [TestMethod]
+        public void Where_Parallel()
+        {
+            XDatabaseContext historicalContext = new XDatabaseContext(SampleDatabase.XDatabaseContext) { RequestedAsOfDateTime = new DateTime(2017, 12, 04, 00, 00, 00, DateTimeKind.Utc) };
+            Assert.AreEqual(3000, historicalContext.Query("readRange \"3d\" WebRequest\r\nwhere [ID] != \"\"").RunAndDispose());
+            Assert.AreEqual(732, historicalContext.Query("readRange \"3d\" WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) = \"\"").RunAndDispose());
         }
     }
 }

--- a/XForm/XForm.Test/Verbs/WhereTests.cs
+++ b/XForm/XForm.Test/Verbs/WhereTests.cs
@@ -16,85 +16,85 @@ namespace XForm.Test.Verbs
         public void Where_Variations()
         {
             // String >
-            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] >= \"0\"").RunAndDispose());
-            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] >= \"a\"").RunAndDispose());
+            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] >= \"0\"").Count());
+            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] >= \"a\"").Count());
 
             // String StartsWith
-            Assert.AreEqual((long)111, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] |> \"1\"").RunAndDispose());
-            Assert.AreEqual((long)1, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] |> \"999\"").RunAndDispose());
-            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] |> \"10000\"").RunAndDispose());
+            Assert.AreEqual((long)111, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] |> \"1\"").Count());
+            Assert.AreEqual((long)1, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] |> \"999\"").Count());
+            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] |> \"10000\"").Count());
 
             // String Contains
-            Assert.AreEqual((long)19, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] : \"99\"").RunAndDispose());
-            Assert.AreEqual((long)1, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] : \"999\"").RunAndDispose());
-            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] : \"9999\"").RunAndDispose());
+            Assert.AreEqual((long)19, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] : \"99\"").Count());
+            Assert.AreEqual((long)1, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] : \"999\"").Count());
+            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] : \"9999\"").Count());
 
             // String Equals
-            Assert.AreEqual((long)1, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] = \"9\"").RunAndDispose());
-            Assert.AreEqual((long)1, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] = \"999\"").RunAndDispose());
-            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] = \"9999\"").RunAndDispose());
+            Assert.AreEqual((long)1, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] = \"9\"").Count());
+            Assert.AreEqual((long)1, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] = \"999\"").Count());
+            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] = \"9999\"").Count());
 
 
             // EnumColumn
-            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] > \"2017\"").RunAndDispose());
-            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] > \"2017-13\"").RunAndDispose());
-            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] < \"2017-13\"").RunAndDispose());
+            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] > \"2017\"").Count());
+            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] > \"2017-13\"").Count());
+            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] < \"2017-13\"").Count());
 
-            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] |> \"2017-1\"").RunAndDispose());
-            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] |> \"2117-1\"").RunAndDispose());
-            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] |> \"017\"").RunAndDispose());
+            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] |> \"2017-1\"").Count());
+            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] |> \"2117-1\"").Count());
+            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] |> \"017\"").Count());
 
-            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"017\"").RunAndDispose());
-            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"2017\"").RunAndDispose());
-            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"2018\"").RunAndDispose());
-            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"-12-\"").RunAndDispose());
+            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"017\"").Count());
+            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"2017\"").Count());
+            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"2018\"").Count());
+            Assert.AreEqual((long)1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"-12-\"").Count());
 
             // Matches Excel
-            Assert.AreEqual((long)103, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"0z\"").RunAndDispose());
-            Assert.AreEqual((long)19, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"00Z\"").RunAndDispose());
-            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"0ZA\"").RunAndDispose());
+            Assert.AreEqual((long)103, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"0z\"").Count());
+            Assert.AreEqual((long)19, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"00Z\"").Count());
+            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"0ZA\"").Count());
 
             // Numeric
-            Assert.AreEqual((long)999, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 0").RunAndDispose());
-            Assert.AreEqual((long)998, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 1").RunAndDispose());
-            Assert.AreEqual((long)500, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 499").RunAndDispose());
-            Assert.AreEqual((long)1, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 998").RunAndDispose());
-            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 999").RunAndDispose());
+            Assert.AreEqual((long)999, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 0").Count());
+            Assert.AreEqual((long)998, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 1").Count());
+            Assert.AreEqual((long)500, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 499").Count());
+            Assert.AreEqual((long)1, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 998").Count());
+            Assert.AreEqual((long)0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 999").Count());
 
             // Order shouldn't matter
-            Assert.AreEqual((long)50, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"0z\" AND Cast([ID], Int32) > 499").RunAndDispose());
-            Assert.AreEqual((long)50, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 499 AND [EventTime] : \"0z\"").RunAndDispose());
-            Assert.AreEqual((long)50, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 499\r\nwhere [EventTime] : \"0z\"").RunAndDispose());
-            Assert.AreEqual((long)50, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"0z\"\r\nwhere Cast([ID], Int32) > 499").RunAndDispose());
+            Assert.AreEqual((long)50, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"0z\" AND Cast([ID], Int32) > 499").Count());
+            Assert.AreEqual((long)50, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 499 AND [EventTime] : \"0z\"").Count());
+            Assert.AreEqual((long)50, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([ID], Int32) > 499\r\nwhere [EventTime] : \"0z\"").Count());
+            Assert.AreEqual((long)50, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"0z\"\r\nwhere Cast([ID], Int32) > 499").Count());
         }
 
         [TestMethod]
         public void Where_ContainsChaining()
         {
             // Useful, but want to find a test which causes IndexOutOfRangeException if bulk contains is used on the second clause.
-            Assert.AreEqual((long)50, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"00:\"\r\nwhere [EventTime] : \"00\"\r\nlimit 50").RunAndDispose());
+            Assert.AreEqual((long)50, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [EventTime] : \"00:\"\r\nwhere [EventTime] : \"00\"\r\nlimit 50").Count());
         }
 
         [TestMethod]
         public void Where_Cascading()
         {
             // Where all, then some
-            Assert.AreEqual(58, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] != \"-1\"\r\nwhere [ClientBrowser]: \"Chrome 45\"").RunAndDispose());
+            Assert.AreEqual(58, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] != \"-1\"\r\nwhere [ClientBrowser]: \"Chrome 45\"").Count());
 
             // Where none, then anything
-            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] = \"-1\"\r\nwhere [ClientBrowser]: \"Chrome 45\"").RunAndDispose());
+            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ID] = \"-1\"\r\nwhere [ClientBrowser]: \"Chrome 45\"").Count());
 
             // Where some, then nothing
-            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientRegion] = \"CN\"\r\nwhere [ClientRegion] = \"US\"").RunAndDispose());
+            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientRegion] = \"CN\"\r\nwhere [ClientRegion] = \"US\"").Count());
 
             // Where some, then same (all kept)
-            Assert.AreEqual(235, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientRegion] = \"CN\"\r\nwhere [ClientRegion] = \"CN\"").RunAndDispose());
+            Assert.AreEqual(235, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientRegion] = \"CN\"\r\nwhere [ClientRegion] = \"CN\"").Count());
 
             // Where some, then all (all kept)
-            Assert.AreEqual(235, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientRegion] = \"CN\"\r\nwhere [ID] != \"-1\"").RunAndDispose());
+            Assert.AreEqual(235, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientRegion] = \"CN\"\r\nwhere [ID] != \"-1\"").Count());
 
             // Where some, then narrowing (some kept)
-            Assert.AreEqual(159, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientRegion] = \"CN\"\r\nwhere [ClientBrowser] : \"Chrome\"").RunAndDispose());
+            Assert.AreEqual(159, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientRegion] = \"CN\"\r\nwhere [ClientBrowser] : \"Chrome\"").Count());
         }
 
         [TestMethod]
@@ -104,86 +104,86 @@ namespace XForm.Test.Verbs
             // Test queries with 'Where' on an enum column for varying 'Where enum' optimized paths.
 
             // Where for a value that's not found - optimizes to 'None'
-            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]: \"Not Found\"").RunAndDispose());
+            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]: \"Not Found\"").Count());
 
             // Where which includes all values - optimizes to 'All'
-            Assert.AreEqual(1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser] < \"ZZZ\"").RunAndDispose());
+            Assert.AreEqual(1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser] < \"ZZZ\"").Count());
 
             // Where for a single value - optimizes to Equals a single enum
-            Assert.AreEqual(chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser] = \"Chrome 45\"").RunAndDispose());
-            Assert.AreEqual(chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]: \"Chrome 45\"").RunAndDispose());
-            Assert.AreEqual(chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]:: \"Chrome 45\"").RunAndDispose());
-            Assert.AreEqual(chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser] |> \"Chrome 45\"").RunAndDispose());
+            Assert.AreEqual(chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser] = \"Chrome 45\"").Count());
+            Assert.AreEqual(chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]: \"Chrome 45\"").Count());
+            Assert.AreEqual(chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]:: \"Chrome 45\"").Count());
+            Assert.AreEqual(chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser] |> \"Chrome 45\"").Count());
 
             // Where for all but one value - optimizes to Not Equals a single enum
-            Assert.AreEqual(1000 - chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser] > \"Chrome 45\"").RunAndDispose());
-            Assert.AreEqual(1000 - chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser] != \"Chrome 45\"").RunAndDispose());
-            Assert.AreEqual(1000 - chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere not [ClientBrowser] : \"Chrome 45\"").RunAndDispose());
+            Assert.AreEqual(1000 - chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser] > \"Chrome 45\"").Count());
+            Assert.AreEqual(1000 - chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser] != \"Chrome 45\"").Count());
+            Assert.AreEqual(1000 - chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere not [ClientBrowser] : \"Chrome 45\"").Count());
 
             // Where for a set - optimizes to a set contains check on enum values
-            Assert.AreEqual(644, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser] : \"Chrome\"").RunAndDispose());
+            Assert.AreEqual(644, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser] : \"Chrome\"").Count());
 
             // Cascading Where with the same condition
-            Assert.AreEqual(chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]: \"Chrome 45\"\r\nwhere [ClientBrowser] = \"Chrome 45\"").RunAndDispose());
+            Assert.AreEqual(chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]: \"Chrome 45\"\r\nwhere [ClientBrowser] = \"Chrome 45\"").Count());
 
             // Cascading Where with a narrowing condition
-            Assert.AreEqual(chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]: \"Chrome 4\"\r\nwhere [ClientBrowser] = \"Chrome 45\"").RunAndDispose());
+            Assert.AreEqual(chrome45Count, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]: \"Chrome 4\"\r\nwhere [ClientBrowser] = \"Chrome 45\"").Count());
 
             // Cascading Where with conflicting conditions
-            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]: \"Chrome 5\"\r\nwhere [ClientBrowser] = \"Chrome 45\"").RunAndDispose());
+            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [ClientBrowser]: \"Chrome 5\"\r\nwhere [ClientBrowser] = \"Chrome 45\"").Count());
         }
 
         [TestMethod]
         public void Where_EmptyAndNull()
         {
             // Where Empty, enum and non-enum
-            Assert.AreEqual(244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] = \"\"").RunAndDispose());
-            Assert.AreEqual(1000 - 244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] != \"\"").RunAndDispose());
+            Assert.AreEqual(244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] = \"\"").Count());
+            Assert.AreEqual(1000 - 244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] != \"\"").Count());
 
             // Where Not Empty, enum and non-enum
-            Assert.AreEqual(244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] = \"\"").RunAndDispose());
-            Assert.AreEqual(1000 - 244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] != \"\"").RunAndDispose());
+            Assert.AreEqual(244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] = \"\"").Count());
+            Assert.AreEqual(1000 - 244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] != \"\"").Count());
 
             // Where Not Not Empty
-            Assert.AreEqual(244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere not [IsPremiumUser] != \"\"").RunAndDispose());
-            Assert.AreEqual(1000 - 244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere not [DaysSinceJoined] = \"\"").RunAndDispose());
+            Assert.AreEqual(244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere not [IsPremiumUser] != \"\"").Count());
+            Assert.AreEqual(1000 - 244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere not [DaysSinceJoined] = \"\"").Count());
 
             // Where Contains Empty, no matches (not an error so you can type without error)
-            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] : \"\"").RunAndDispose());
-            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] : \"\"").RunAndDispose());
+            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] : \"\"").Count());
+            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] : \"\"").Count());
 
             // Where ContainsExact Empty, no matches, not an error
-            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] :: \"\"").RunAndDispose());
-            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] :: \"\"").RunAndDispose());
+            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] :: \"\"").Count());
+            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] :: \"\"").Count());
 
             // Where StartsWith Empty, no matches, not an error
-            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] |> \"\"").RunAndDispose());
-            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] |> \"\"").RunAndDispose());
+            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] |> \"\"").Count());
+            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] |> \"\"").Count());
 
             // Where null against strings (no matches)
-            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] = null").RunAndDispose());
-            Assert.AreEqual(1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] != null").RunAndDispose());
-            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] = null").RunAndDispose());
-            Assert.AreEqual(1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] != null").RunAndDispose());
+            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] = null").Count());
+            Assert.AreEqual(1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [IsPremiumUser] != null").Count());
+            Assert.AreEqual(0, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] = null").Count());
+            Assert.AreEqual(1000, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere [DaysSinceJoined] != null").Count());
 
             // Where null after cast (matches)
-            Assert.AreEqual(244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) = null").RunAndDispose());
-            Assert.AreEqual(1000 - 244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) != null").RunAndDispose());
+            Assert.AreEqual(244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) = null").Count());
+            Assert.AreEqual(1000 - 244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) != null").Count());
 
             // Where empty after cast (synonym for null)
-            Assert.AreEqual(244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) = \"\"").RunAndDispose());
-            Assert.AreEqual(1000 - 244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) != \"\"").RunAndDispose());
+            Assert.AreEqual(244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) = \"\"").Count());
+            Assert.AreEqual(1000 - 244, SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) != \"\"").Count());
 
             // Where invalid after cast (error)
-            Verify.Exception<UsageException>(() => SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) != \"invalid\"").RunAndDispose());
+            Verify.Exception<UsageException>(() => SampleDatabase.XDatabaseContext.Query("read WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) != \"invalid\"").Count());
         }
 
         [TestMethod]
         public void Where_Parallel()
         {
             XDatabaseContext historicalContext = new XDatabaseContext(SampleDatabase.XDatabaseContext) { RequestedAsOfDateTime = new DateTime(2017, 12, 04, 00, 00, 00, DateTimeKind.Utc) };
-            Assert.AreEqual(3000, historicalContext.Query("readRange \"3d\" WebRequest\r\nwhere [ID] != \"\"").RunAndDispose());
-            Assert.AreEqual(732, historicalContext.Query("readRange \"3d\" WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) = \"\"").RunAndDispose());
+            Assert.AreEqual(3000, historicalContext.Query("readRange \"3d\" WebRequest\r\nwhere [ID] != \"\"").Count());
+            Assert.AreEqual(732, historicalContext.Query("readRange \"3d\" WebRequest\r\nwhere Cast([IsPremiumUser], Boolean) = \"\"").Count());
         }
     }
 }

--- a/XForm/XForm/Data/XArray.cs
+++ b/XForm/XForm/Data/XArray.cs
@@ -301,5 +301,13 @@ namespace XForm.Data
                 return XArray.All(array, this.Count, nulls);
             }
         }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is XArray)) return false;
+
+            XArray other = (XArray)obj;
+            return other.Array == this.Array && other.NullRows == this.NullRows && other.Selector == this.Selector;
+        }
     }
 }

--- a/XForm/XForm/Data/XArray.cs
+++ b/XForm/XForm/Data/XArray.cs
@@ -96,6 +96,12 @@ namespace XForm.Data
         /// <returns>XArray wrapping the array from [0, Count)</returns>
         public static XArray All(Array array, int count = -1, bool[] nulls = null, bool isSingle = false)
         {
+            if(array == null)
+            {
+                if (count == 0 || count == -1) return XArray.Empty;
+                throw new ArgumentNullException("array");
+            }
+
             if (count == -1) count = array.Length;
             if (isSingle == false && count > array.Length) throw new ArgumentOutOfRangeException("length");
             if (isSingle == false && nulls != null && count > nulls.Length) throw new ArgumentOutOfRangeException("length");

--- a/XForm/XForm/Data/XArray.cs
+++ b/XForm/XForm/Data/XArray.cs
@@ -309,5 +309,10 @@ namespace XForm.Data
             XArray other = (XArray)obj;
             return other.Array == this.Array && other.NullRows == this.NullRows && other.Selector == this.Selector;
         }
+
+        public override int GetHashCode()
+        {
+            return (this.Array?.GetHashCode() ?? 0) ^ (this.NullRows?.GetHashCode() ?? 0) ^ (this.Selector?.GetHashCode() ?? 0);
+        }
     }
 }

--- a/XForm/XForm/Extensions/StreamProviderExtensions.cs
+++ b/XForm/XForm/Extensions/StreamProviderExtensions.cs
@@ -20,6 +20,11 @@ namespace XForm.Extensions
     {
         public const string DateTimeFolderFormat = "yyyy.MM.dd HH.mm.ssZ";
 
+        public static bool Exists(this IStreamProvider streamProvider, string logicalPath)
+        {
+            return streamProvider.Attributes(logicalPath).Exists;
+        }
+
         public static string Path(this IStreamProvider streamProvider, LocationType type, string tableName, string extension)
         {
             return System.IO.Path.Combine(type.ToString(), tableName + extension);

--- a/XForm/XForm/Extensions/StringExtensions.cs
+++ b/XForm/XForm/Extensions/StringExtensions.cs
@@ -7,6 +7,12 @@ namespace XForm.Extensions
 {
     public static class StringExtensions
     {
+        public static string RemoveTrailing(this string text, char c)
+        {
+            if (!string.IsNullOrEmpty(text) && text[text.Length - 1] == c) return text.Substring(0, text.Length - 1);
+            return text;
+        }
+
         public static string BeforeFirst(this string text, char c)
         {
             if (string.IsNullOrEmpty(text)) return string.Empty;

--- a/XForm/XForm/Extensions/XTableExtensions.cs
+++ b/XForm/XForm/Extensions/XTableExtensions.cs
@@ -222,7 +222,7 @@ namespace XForm.Extensions
         public static long Save(this IXTable source, string tableName, XDatabaseContext context, int xarraySize = DefaultBatchSize)
         {
             string tableRootPath = context.StreamProvider.Path(LocationType.Table, tableName, CrawlType.Full, context.RequestedAsOfDateTime);
-            return new BinaryTableWriter(source, context, tableRootPath).RunAndDispose().RowCount;
+            return BinaryTableWriter.Build(source, context, tableRootPath).RunAndDispose().RowCount;
         }
         #endregion
 

--- a/XForm/XForm/Extensions/XTableExtensions.cs
+++ b/XForm/XForm/Extensions/XTableExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 
 using XForm.Data;
@@ -71,7 +72,7 @@ namespace XForm.Extensions
         /// <param name="cancellationToken">Token to allow early cancellation</param>
         /// <param name="batchSize">Number of rows to process on each iteration</param>
         /// <returns>Count of rows in this source or query.</returns>
-        public static long RunAndDispose(this IXTable pipeline, CancellationToken cancellationToken = default(CancellationToken), int batchSize = DefaultBatchSize)
+        public static RunResult RunAndDispose(this IXTable pipeline, CancellationToken cancellationToken = default(CancellationToken), int batchSize = DefaultBatchSize)
         {
             using (pipeline)
             {
@@ -86,16 +87,30 @@ namespace XForm.Extensions
         /// <param name="cancellationToken">Token to allow early cancellation</param>
         /// <param name="batchSize">Number of rows to process on each iteration</param>
         /// <returns>Count of rows in this source or query.</returns>
-        public static long RunWithoutDispose(this IXTable pipeline, CancellationToken cancellationToken = default(CancellationToken), int batchSize = DefaultBatchSize)
+        public static RunResult RunWithoutDispose(this IXTable pipeline, CancellationToken cancellationToken = default(CancellationToken), int batchSize = DefaultBatchSize)
         {
-            long rowsWritten = 0;
+            RunResult result = new RunResult();
+            Stopwatch w = Stopwatch.StartNew();
+
             while (true)
             {
                 int batchCount = pipeline.Next(batchSize, cancellationToken);
-                if (batchCount == 0) break;
-                rowsWritten += batchCount;
+                result.RowCount += batchCount;
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                else if (batchCount == 0)
+                {
+                    result.IsComplete = true;
+                    break;
+                }
+                
             }
-            return rowsWritten;
+
+            result.Elapsed = w.Elapsed;
+            return result;
         }
 
         /// <summary>
@@ -112,30 +127,15 @@ namespace XForm.Extensions
         {
             using (CancellationTokenSource source = new CancellationTokenSource())
             {
+                // Setup the timeout
                 CancellationToken cancellationToken = source.Token;
                 if (timeout != TimeSpan.Zero && timeout != TimeSpan.MaxValue) source.CancelAfter(timeout);
 
-                RunResult result = new RunResult();
+                // Run until timeout
+                RunResult result = RunWithoutDispose(pipeline, cancellationToken, batchSize);
+
+                // Tag the timeout on the result and return it
                 result.Timeout = timeout;
-
-                Stopwatch w = Stopwatch.StartNew();
-                while (true)
-                {
-                    int count = pipeline.Next(batchSize, cancellationToken);
-                    result.RowCount += count;
-
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        break;
-                    }
-                    else if (count == 0)
-                    {
-                        result.IsComplete = true;
-                        break;
-                    }
-                }
-
-                result.Elapsed = w.Elapsed;
                 return result;
             }
         }
@@ -150,7 +150,7 @@ namespace XForm.Extensions
         /// <returns>Count of rows in this source or query.</returns>
         public static long Count(this IXTable pipeline, CancellationToken cancellationToken = default(CancellationToken), int batchSize = DefaultBatchSize)
         {
-            return RunAndDispose(pipeline, cancellationToken, batchSize);
+            return RunAndDispose(pipeline, cancellationToken, batchSize).RowCount;
         }
 
         /// <summary>
@@ -222,8 +222,38 @@ namespace XForm.Extensions
         public static long Save(this IXTable source, string tableName, XDatabaseContext context, int xarraySize = DefaultBatchSize)
         {
             string tableRootPath = context.StreamProvider.Path(LocationType.Table, tableName, CrawlType.Full, context.RequestedAsOfDateTime);
-            return new BinaryTableWriter(source, context, tableRootPath).RunAndDispose();
+            return new BinaryTableWriter(source, context, tableRootPath).RunAndDispose().RowCount;
         }
+        #endregion
+
+        #region ConcatenatedTable handling
+        /// <summary>
+        ///  WrapParallel builds a parallel copy of the query stage for each source in ConcatenatingTable sources.
+        ///  It is used to allow running optimized query stages and running in parallel when multiple tables are involved.
+        /// </summary>
+        /// <remarks>
+        ///  WrapParallel can only be used by verbs where the output when run on the concatenated inputs rows from many sources
+        ///  produces the same output as running in parallel on each source and then concatenating the result rows.
+        /// </remarks>
+        /// <param name="source">IXTable to wrap</param>
+        /// <param name="builder">Wrapping function</param>
+        /// <returns>Wrapped IXTable</returns>
+        public static IXTable WrapParallel(this IXTable source, XqlParser parser, Func<IXTable, IXTable> builder)
+        {
+            ConcatenatedTable cSource = source as ConcatenatedTable;
+            if(cSource != null)
+            {
+                Position currentPosition = parser.CurrentPosition;
+                return new ConcatenatedTable(cSource.Sources.Select((s) =>
+                {
+                    parser.RewindTo(currentPosition);
+                    return builder(s);
+                }));
+            }
+
+            return builder(source);
+        }
+
         #endregion
     }
 }

--- a/XForm/XForm/Extensions/XTableExtensions.cs
+++ b/XForm/XForm/Extensions/XTableExtensions.cs
@@ -244,7 +244,7 @@ namespace XForm.Extensions
             if(cSource != null)
             {
                 Position currentPosition = parser.CurrentPosition;
-                return new ConcatenatedTable(cSource.Sources.Select((s) =>
+                return ConcatenatedTable.Build(cSource.Sources.Select((s) =>
                 {
                     parser.RewindTo(currentPosition);
                     return builder(s);

--- a/XForm/XForm/Functions/Cast.cs
+++ b/XForm/XForm/Functions/Cast.cs
@@ -5,8 +5,6 @@ using System;
 
 using XForm.Columns;
 using XForm.Data;
-using XForm.Extensions;
-using XForm.Query;
 using XForm.Types;
 
 namespace XForm.Functions

--- a/XForm/XForm/Http/BackgroundWebServer.cs
+++ b/XForm/XForm/Http/BackgroundWebServer.cs
@@ -132,10 +132,9 @@ namespace XForm
                 {
                     HandleRequest(this.Listener.GetContext());
                 }
-                catch (HttpListenerException ex)
+                catch (HttpListenerException)
                 {
-                    // Happens when connection to client lost before response sent
-                    Trace.TraceWarning(String.Format("BackgroundWebServer: Lost Connection During Request. Retrying. Error: {0}", ex.ToString()));
+                    // Happens when connection to client lost before response sent (request cancelled). Do nothing.
                 }
                 catch (ThreadAbortException)
                 {

--- a/XForm/XForm/HttpService.cs
+++ b/XForm/XForm/HttpService.cs
@@ -261,10 +261,15 @@ namespace XForm
         private const int HttpListener_RequestAborted = 1229;
         private void ReportError(IHttpRequest request, IHttpResponse response, Exception ex)
         {
+            // Don't log connections closed
             HttpListenerException hle = ex as HttpListenerException;
             if (hle != null && (uint)hle.ErrorCode == HttpListener_RequestAborted) return;
 
-            Trace.WriteLine($"ERROR: {request.Url}\r\n{ex.ToString()}");
+            // Log locally except UsageExceptions
+            if(!(ex is UsageException))
+            {
+                Trace.WriteLine($"ERROR: {request.Url}\r\n{ex.ToString()}");
+            }
 
             using (ITabularWriter writer = WriterForFormat("json", response))
             {

--- a/XForm/XForm/HttpService.cs
+++ b/XForm/XForm/HttpService.cs
@@ -142,12 +142,7 @@ namespace XForm
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"ERROR: {request.Url}\r\n{ex.ToString()}");
-
-                using (ITabularWriter writer = WriterForFormat("json", response))
-                {
-                    WriteException(ex, writer);
-                }
+                ReportError(request, response, ex);
             }
         }
 

--- a/XForm/XForm/IO/BinaryTableReader.cs
+++ b/XForm/XForm/IO/BinaryTableReader.cs
@@ -154,7 +154,7 @@ namespace XForm.IO
             Reset();
         }
 
-        public static IXTable Read(IStreamProvider streamProvider, string tableRootPath)
+        public static IXTable Build(IStreamProvider streamProvider, string tableRootPath)
         {
             TableMetadata metadata = TableMetadataSerializer.Read(streamProvider, tableRootPath);
 
@@ -162,7 +162,7 @@ namespace XForm.IO
             {
                 // If this table has partitions, load the parts (*allowing* recursive partitioning)
                 // This allows partitioning by a column where one column value still will hit the size limit.
-                return ConcatenatedTable.Build(metadata.Partitions.Select((partition) => BinaryTableReader.Read(streamProvider, Path.Combine(tableRootPath, partition))));
+                return ConcatenatedTable.Build(metadata.Partitions.Select((partition) => BinaryTableReader.Build(streamProvider, Path.Combine(tableRootPath, partition))));
             }
             else
             {
@@ -175,7 +175,7 @@ namespace XForm.IO
 
         public string TablePath { get; private set; }
         public string Query => _metadata.Query;
-        public int Count => _metadata.RowCount;
+        public int Count => (int)_metadata.RowCount;
         public int CurrentRowCount { get; private set; }
 
         public int Next(int desiredCount, CancellationToken cancellationToken)

--- a/XForm/XForm/IO/BinaryTableReader.cs
+++ b/XForm/XForm/IO/BinaryTableReader.cs
@@ -160,7 +160,9 @@ namespace XForm.IO
 
             if (metadata.Partitions.Count > 0)
             {
-                return ConcatenatedTable.Build(metadata.Partitions.Select((partition) => new BinaryTableReader(streamProvider, Path.Combine(tableRootPath, partition))));
+                // If this table has partitions, load the parts (*allowing* recursive partitioning)
+                // This allows partitioning by a column where one column value still will hit the size limit.
+                return ConcatenatedTable.Build(metadata.Partitions.Select((partition) => BinaryTableReader.Read(streamProvider, Path.Combine(tableRootPath, partition))));
             }
             else
             {

--- a/XForm/XForm/IO/BinaryTableWriter.cs
+++ b/XForm/XForm/IO/BinaryTableWriter.cs
@@ -35,6 +35,13 @@ namespace XForm.IO
 
     public class BinaryTableWriter : XTableWrapper
     {
+        /// <summary>
+        ///  File Size limit for each individual column file.
+        ///  2GB because XForm uses integers for row indices and to seek in streams, and so XForm can allocate arrays to hold cached files whole.
+        ///  This may be lowered later to accomodate ideal sizes for cloud storage.
+        /// </summary>
+        public const long ColumnFileSizeLimit = (long)int.MaxValue;
+
         private XDatabaseContext _xDatabaseContext;
         private string _tableRootPath;
 

--- a/XForm/XForm/IO/BinaryTableWriter.cs
+++ b/XForm/XForm/IO/BinaryTableWriter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,12 +25,119 @@ namespace XForm.IO
             string filePath = context.Parser.NextOutputTableName();
             if (filePath.StartsWith("Table\\", StringComparison.OrdinalIgnoreCase) || filePath.EndsWith(".xform", StringComparison.OrdinalIgnoreCase))
             {
-                return new BinaryTableWriter(source, context, filePath);
+                return BinaryTableWriter.Build(source, context, filePath);
             }
             else
             {
                 return new TabularFileWriter(source, context.StreamProvider, filePath);
             }
+        }
+    }
+
+    public class PartitionedBinaryTableWriter : XTableWrapper
+    {
+        private XDatabaseContext _xDatabaseContext;
+        private string _tableRootPath;
+
+        private BinaryTableWriter _partitionWriter;
+        private TableMetadata _metadata;
+
+        private Func<XArray>[] _getters;
+        private XArray[] _currentArrays;
+
+        public PartitionedBinaryTableWriter(IXTable source, XDatabaseContext xDatabaseContext, string tableRootPath) : base(source)
+        {
+            _xDatabaseContext = xDatabaseContext;
+            _tableRootPath = tableRootPath;
+
+            _metadata = new TableMetadata();
+            _metadata.Query = xDatabaseContext.CurrentQuery;
+
+            _currentArrays = new XArray[source.Columns.Count];
+            _getters = _source.Columns.Select((col) => col.CurrentGetter()).ToArray();
+        }
+
+        private void NextPartitionWriter()
+        {
+            if (_partitionWriter != null) _partitionWriter.Dispose();
+
+            string nextPartitionId = _metadata.Partitions.Count.ToString();
+            _partitionWriter = BinaryTableWriter.BuildPartition(_source, _xDatabaseContext, Path.Combine(_tableRootPath, nextPartitionId));
+            _metadata.Partitions.Add(nextPartitionId);
+        }
+
+        public override int Next(int desiredCount, CancellationToken cancellationToken)
+        {
+            if (_partitionWriter == null) NextPartitionWriter();
+
+            int count = _source.Next(desiredCount, cancellationToken);
+            if (count == 0)
+            {
+                // Ensure Writers flush
+                DisposeWriters();
+                return 0;
+            }
+
+            // Get the next set of arrays (parallel might not be safe)
+            for (int i = 0; i < _getters.Length; ++i)
+            {
+                _currentArrays[i] = _getters[i]();
+            }
+
+            while (true)
+            {
+                // Write as many rows as possible
+                int countWritten = _partitionWriter.Write(_currentArrays);
+                _metadata.RowCount += countWritten;
+
+                // If all rows fit, stop
+                if (countWritten == count) break;
+
+                // Otherwise, open a new partition and continue writing
+                NextPartitionWriter();
+
+                int countLeft = _currentArrays[0].Count - countWritten;
+                for (int i = 0; i < _getters.Length; ++i)
+                {
+                    _currentArrays[i] = _currentArrays[i].Slice(countWritten, countLeft);
+                }
+            }
+
+            _metadata.RowCount += count;
+            return count;
+        }
+
+        public override void Reset()
+        {
+            _source.Reset();
+            DisposeWriters();
+        }
+
+        private void DisposeWriters()
+        {
+            if (_partitionWriter != null)
+            {
+                _metadata.Schema = _partitionWriter.Metadata.Schema;
+
+                _partitionWriter.Dispose();
+                _partitionWriter = null;
+            }
+
+            // Write the schema and query only if the table was valid
+            if (_metadata.RowCount > 0)
+            {
+                // Write table metadata for the partition set
+                TableMetadataSerializer.Write(_xDatabaseContext.StreamProvider, _tableRootPath, _metadata);
+
+                // On Dispose, tell the StreamProvider to publish the table
+                _xDatabaseContext.StreamProvider.Publish(_tableRootPath);
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            DisposeWriters();
         }
     }
 
@@ -40,38 +148,43 @@ namespace XForm.IO
         ///  2GB because XForm uses integers for row indices and to seek in streams, and so XForm can allocate arrays to hold cached files whole.
         ///  This may be lowered later to accomodate ideal sizes for cloud storage.
         /// </summary>
-        public const long ColumnFileSizeLimit = (long)int.MaxValue;
+        public static long ColumnFileSizeLimit = (long)int.MaxValue;
 
+        public TableMetadata Metadata { get; private set; }
         private XDatabaseContext _xDatabaseContext;
         private string _tableRootPath;
+        private IColumnWriter[] _writers;
 
         private Func<XArray>[] _getters;
         private XArray[] _currentArrays;
-        private IColumnWriter[] _writers;
 
-        private TableMetadata _metadata;
-
-        public BinaryTableWriter(IXTable source, XDatabaseContext xDatabaseContext, string tableRootPath) : base(source)
+        private BinaryTableWriter(IXTable source, XDatabaseContext xDatabaseContext, string tableRootPath) : base(source)
         {
             _xDatabaseContext = xDatabaseContext;
             _tableRootPath = tableRootPath;
 
+            Metadata = new TableMetadata();
+            Metadata.Query = xDatabaseContext.CurrentQuery;
 
-            _metadata = new TableMetadata();
-            _metadata.Query = xDatabaseContext.CurrentQuery;
-
-            int columnCount = source.Columns.Count;
-            _getters = new Func<XArray>[columnCount];
-            _currentArrays = new XArray[columnCount];
-
-            // Subscribe to all of the columns
-            for (int i = 0; i < columnCount; ++i)
-            {
-                _getters[i] = source.Columns[i].CurrentGetter();
-            }
+            // Defer subscribing to columns; if wrapped in a PartitionedBinaryTableWriter, it will take that over.
         }
 
+        /// <summary>
+        ///  Build constructs an IXTable to write a (potentially multi-partition) Binary Table.
+        /// </summary>
+        /// <param name="source">IXTable to write data from</param>
+        /// <param name="xDatabaseContext">XDatabaseContext for database</param>
+        /// <param name="tableRootPath">Table Path (Table\[Name]\Full\[UtcDateTime])</param>
+        /// <returns>IXTable to enumerate to write the table and pass through rows</returns>
         public static IXTable Build(IXTable source, XDatabaseContext xDatabaseContext, string tableRootPath)
+        {
+            //return new BinaryTableWriter(source, xDatabaseContext, tableRootPath);
+
+            // Enable Partitioning
+            return new PartitionedBinaryTableWriter(source, xDatabaseContext, tableRootPath);
+        }
+
+        internal static BinaryTableWriter BuildPartition(IXTable source, XDatabaseContext xDatabaseContext, string tableRootPath)
         {
             return new BinaryTableWriter(source, xDatabaseContext, tableRootPath);
         }
@@ -99,12 +212,19 @@ namespace XForm.IO
                     column = column.ChangeType(typeof(String8));
                 }
 
-                _metadata.Schema.Add(column);
+                Metadata.Schema.Add(column);
             }
         }
 
         public override int Next(int desiredCount, CancellationToken cancellationToken)
         {
+            // Subscribe to all columns (on first call, just before Next())
+            if(_currentArrays == null)
+            {
+                _currentArrays = new XArray[_source.Columns.Count];
+                _getters = _source.Columns.Select((col) => col.CurrentGetter()).ToArray();
+            }
+
             int count = _source.Next(desiredCount, cancellationToken);
             if (count == 0)
             {
@@ -126,26 +246,66 @@ namespace XForm.IO
         {
             if (_writers == null) BuildWriters();
 
-            int count = arrays[0].Count;
+            int countWritten = arrays[0].Count;
 
-            // Write them out (Parallel safe)
+            // Try to write all rows
+            bool succeeded = WriteAll(arrays);
+
+            if (!succeeded)
+            {
+                // If the partition is full, write single rows until full
+                countWritten = WriteRowByRow(arrays);
+            }
+
+            Metadata.RowCount += countWritten;
+            return countWritten;
+        }
+
+        private bool WriteAll(XArray[] arrays)
+        {
+            // Validate partition isn't full
+            bool canAppend = true;
+            for (int i = 0; i < _writers.Length; ++i)
+            {
+                canAppend &= _writers[i].CanAppend(arrays[i]);
+                if (!canAppend) return false;
+            }
+
+            // Write all rows if not
             if (_xDatabaseContext.ForceSingleThreaded)
             {
-                for (int i = 0; i < _getters.Length; ++i)
+                for (int i = 0; i < _writers.Length; ++i)
                 {
                     _writers[i].Append(arrays[i]);
                 }
             }
             else
             {
-                Parallel.For(0, _getters.Length, (i) =>
+                Parallel.For(0, _writers.Length, (i) =>
                 {
                     _writers[i].Append(arrays[i]);
                 });
             }
 
-            _metadata.RowCount += count;
-            return count;
+            return true;
+        }
+
+        private int WriteRowByRow(XArray[] arrays)
+        {
+            XArray[] currentSingleRow = new XArray[_writers.Length];
+            int countWritten;
+
+            for (countWritten = 0; countWritten < arrays[0].Count; ++countWritten)
+            {
+                for (int i = 0; i < _writers.Length; ++i)
+                {
+                    currentSingleRow[i] = arrays[i].Slice(countWritten, countWritten + 1);
+                }
+
+                if (!WriteAll(currentSingleRow)) break;
+            }
+
+            return countWritten;
         }
 
         public override void Reset()
@@ -166,10 +326,10 @@ namespace XForm.IO
                 _writers = null;
 
                 // Write the schema and query only if the table was valid
-                if (_metadata.Schema.Count > 0)
+                if (Metadata.RowCount > 0)
                 {
                     // Write table metadata for the completed table
-                    TableMetadataSerializer.Write(_xDatabaseContext.StreamProvider, _tableRootPath, _metadata);
+                    TableMetadataSerializer.Write(_xDatabaseContext.StreamProvider, _tableRootPath, Metadata);
 
                     // On Dispose, tell the StreamProvider to publish the table
                     _xDatabaseContext.StreamProvider.Publish(_tableRootPath);

--- a/XForm/XForm/IO/ConvertingReaderWriter.cs
+++ b/XForm/XForm/IO/ConvertingReaderWriter.cs
@@ -16,6 +16,9 @@ namespace XForm.IO
         private Func<XArray, XArray> _converter;
         private IColumnWriter _convertedValueWriter;
 
+        private XArray _lastSource;
+        private XArray _lastConverted;
+
         public ConvertingWriter(IColumnWriter convertedValueWriter, Func<XArray, XArray> converter)
         {
             _converter = converter;
@@ -24,9 +27,25 @@ namespace XForm.IO
 
         public Type WritingAsType => _convertedValueWriter.WritingAsType;
 
+        private XArray Convert(XArray xarray)
+        {
+            if (xarray.Equals(_lastSource)) return _lastConverted;
+
+            _lastSource = xarray;
+            _lastConverted = _converter(xarray);
+
+            return _lastConverted;
+
+        }
+
+        public bool CanAppend(XArray xarray)
+        {
+            return _convertedValueWriter.CanAppend(Convert(xarray));
+        }
+
         public void Append(XArray xarray)
         {
-            _convertedValueWriter.Append(_converter(xarray));
+            _convertedValueWriter.Append(Convert(xarray));
         }
 
         public void Dispose()

--- a/XForm/XForm/IO/EnumReaderWriter.cs
+++ b/XForm/XForm/IO/EnumReaderWriter.cs
@@ -325,6 +325,7 @@ namespace XForm.IO
 
             // Build a reader for the values (require caching if we we have row indices)
             IColumnReader valueReader = TypeProviderFactory.TryGetColumnReader(streamProvider, columnType, columnPath, (rowIndexReader != null ? CachingOption.Always : option), typeof(EnumReader));
+            if (valueReader == null) throw new IOException($"No values found in {columnPath}.");
 
             // If there were row indices, wrap the column. Otherwise, return as-is.
             if (rowIndexReader != null) return new EnumReader(valueReader, rowIndexReader);

--- a/XForm/XForm/IO/EnumReaderWriter.cs
+++ b/XForm/XForm/IO/EnumReaderWriter.cs
@@ -214,6 +214,18 @@ namespace XForm.IO
 
         public Type WritingAsType => _valueWriter.WritingAsType;
 
+        public bool CanAppend(XArray xarray)
+        {
+            if(_dictionary == null)
+            {
+                return _valueWriter.CanAppend(xarray);
+            }
+            else
+            {
+                return _rowIndexWriter.CanAppend(xarray);
+            }
+        }
+
         public void Append(XArray xarray)
         {
             // If we already had too many values, we're just writing them out normally

--- a/XForm/XForm/IO/EnumReaderWriter.cs
+++ b/XForm/XForm/IO/EnumReaderWriter.cs
@@ -218,10 +218,12 @@ namespace XForm.IO
         {
             if(_dictionary == null)
             {
+                // If we're no longer in enum mode, verify the raw values fit
                 return _valueWriter.CanAppend(xarray);
             }
             else
             {
+                // Otherwise, verify the indices fit
                 return _rowIndexWriter.CanAppend(xarray);
             }
         }

--- a/XForm/XForm/IO/NullableReaderWriter.cs
+++ b/XForm/XForm/IO/NullableReaderWriter.cs
@@ -35,7 +35,10 @@ namespace XForm.Types
 
         public bool CanAppend(XArray xarray)
         {
-            return (_rowCountWritten + xarray.Count) < BinaryTableWriter.ColumnFileSizeLimit;
+            // We can append if the nulls themselves fit (only one byte each, to be smaller) 
+            //  and the values can fit (should almost always be more limiting)
+            return (_rowCountWritten + xarray.Count) <= BinaryTableWriter.ColumnFileSizeLimit
+                && _valueWriter.CanAppend(xarray);
         }
 
         public void Append(XArray xarray)

--- a/XForm/XForm/IO/NullableReaderWriter.cs
+++ b/XForm/XForm/IO/NullableReaderWriter.cs
@@ -17,7 +17,7 @@ namespace XForm.Types
     public class NullableWriter : IColumnWriter
     {
         private IStreamProvider _streamProvider;
-        private int _rowCountSoFar;
+        private int _rowCountWritten;
         private string _columnPath;
         private IColumnWriter _valueWriter;
         private PrimitiveArrayWriter<bool> _nullWriter;
@@ -33,13 +33,18 @@ namespace XForm.Types
 
         public Type WritingAsType => _valueWriter.WritingAsType;
 
+        public bool CanAppend(XArray xarray)
+        {
+            return (_rowCountWritten + xarray.Count) < BinaryTableWriter.ColumnFileSizeLimit;
+        }
+
         public void Append(XArray xarray)
         {
             // Write the values (without the null markers; we're writing those here)
             _valueWriter.Append(xarray.WithoutNulls());
 
             // Track the row count written so we know how many null=false values to write when we first see a null
-            _rowCountSoFar += xarray.Count;
+            _rowCountWritten += xarray.Count;
 
             // If there are no nulls in this set and none previously, no null markers need to be written
             if (!xarray.HasNulls && _nullWriter == null) return;
@@ -61,7 +66,7 @@ namespace XForm.Types
                 _nullWriter = new PrimitiveArrayWriter<bool>(_streamProvider.OpenWrite(nullsPath));
 
                 // Write false for every value so far
-                int previousCount = _rowCountSoFar - xarray.Count;
+                int previousCount = _rowCountWritten - xarray.Count;
                 Allocator.AllocateToSize(ref _falseArray, 1024);
                 for (int i = 0; i < previousCount; i += 1024)
                 {

--- a/XForm/XForm/IO/TableMetadata.cs
+++ b/XForm/XForm/IO/TableMetadata.cs
@@ -17,7 +17,7 @@ namespace XForm.IO
 {
     public class TableMetadata
     {
-        public int RowCount { get; set; }
+        public long RowCount { get; set; }
         public string Query { get; set; }
         public List<ColumnDetails> Schema { get; set; }
         public List<string> Partitions { get; set; }
@@ -66,7 +66,7 @@ namespace XForm.IO
 
                 mw.Write(block.GetCopy("RowCount"));
                 mw.Write(String8.Empty);
-                mw.Write(metadata.RowCount);
+                mw.Write(String8.FromNumber(metadata.RowCount, new byte[20]));
                 mw.NextRow();
             }
 

--- a/XForm/XForm/IO/TableMetadata.cs
+++ b/XForm/XForm/IO/TableMetadata.cs
@@ -72,6 +72,20 @@ namespace XForm.IO
 
             streamProvider.WriteAllText(Path.Combine(tableRootPath, ConfigQueryPath), metadata.Query);
 
+            if (metadata.Partitions.Count > 0)
+            {
+                using (ITabularWriter pw = TabularFactory.BuildWriter(streamProvider.OpenWrite(Path.Combine(tableRootPath, PartitionsFileName)), PartitionsFileName))
+                {
+                    pw.SetColumns(new string[] { "Name" });
+
+                    foreach(string partition in metadata.Partitions)
+                    {
+                        pw.Write(block.GetCopy(partition));
+                        pw.NextRow();
+                    }
+                }
+            }
+
             s_Cache.Add($"{streamProvider}|{tableRootPath}", metadata);
         }
 

--- a/XForm/XForm/IO/VariableIntegerReaderWriter.cs
+++ b/XForm/XForm/IO/VariableIntegerReaderWriter.cs
@@ -40,6 +40,11 @@ namespace XForm.IO
             return $"{columnPathPrefix}.{PrimitiveTypeProvider<byte>.BinaryFileTypePart(type)}.bin";
         }
 
+        public bool CanAppend(XArray xarray)
+        {
+            return _writer.CanAppend(xarray);
+        }
+
         private static IColumnWriter BuildDirectWriter(IStreamProvider streamProvider, Type type, string columnPathFull)
         {
             // Open the correct *direct* writer for the desired type.

--- a/XForm/XForm/InteractiveRunner.cs
+++ b/XForm/XForm/InteractiveRunner.cs
@@ -131,7 +131,7 @@ namespace XForm
                     IXTable firstTenWrapper = _pipeline;
                     firstTenWrapper = _xDatabaseContext.Query("limit 10 10", firstTenWrapper);
                     firstTenWrapper = _xDatabaseContext.Query("write cout", firstTenWrapper);
-                    lastCount = firstTenWrapper.RunWithoutDispose();
+                    lastCount = firstTenWrapper.Count();
 
                     // Get the count
                     RunResult result = _pipeline.RunUntilTimeout(TimeSpan.FromSeconds(3));

--- a/XForm/XForm/Program.cs
+++ b/XForm/XForm/Program.cs
@@ -152,7 +152,7 @@ namespace XForm
             {
                 using (IXTable source = context.Query(query))
                 {
-                    rowsWritten = source.RunWithoutDispose();
+                    rowsWritten = source.Count();
                 }
             }
 

--- a/XForm/XForm/Query/UsageException.cs
+++ b/XForm/XForm/Query/UsageException.cs
@@ -35,29 +35,47 @@ namespace XForm.Query
 
             if (this.ValidValues != null)
             {
-                // Filter valid values based on prefix typed
-                if (!String.IsNullOrEmpty(this.InvalidValue)) this.ValidValues = this.ValidValues.Where((value) => value.IndexOf(invalidValue, StringComparison.OrdinalIgnoreCase) != -1);
-
-                int filteredCount = this.ValidValues.Count();
-                if (filteredCount == 1)
-                {
-                    // If there's only one value and it exactly matches, return no valid values
-                    if (this.ValidValues.First().Equals(invalidValue, StringComparison.OrdinalIgnoreCase))
-                    {
-                        this.ValidValues = null;
-                    }
-                }
-                else if(filteredCount == 0)
-                {
-                    // If nothing was left after filtering, return the full list
-                    this.ValidValues = validValues;
-                }
+                // Don't filter valid values; the client side should get the whole list
+                // so that it can filter during typing without calling back, including during backspace
 
                 // Always sort expected values
                 if (this.ValidValues != null)
                 {
                     this.ValidValues = this.ValidValues.OrderBy((s) => s);
                 }
+            }
+        }
+
+        /// <summary>
+        ///  Return the filtered list of ValidValues as client IntelliSense should display.
+        ///  The service returns the full list and the client filters it so that Suggest only
+        ///  has to be called once per token rather than once per keystroke.
+        /// </summary>
+        public IEnumerable<string> FilteredValues
+        {
+            get
+            {
+                IEnumerable<string> filteredValues = this.ValidValues;
+
+                // Filter valid values based on prefix typed
+                if (!String.IsNullOrEmpty(this.InvalidValue)) filteredValues = filteredValues.Where((value) => value.IndexOf(this.InvalidValue, StringComparison.OrdinalIgnoreCase) != -1);
+
+                int filteredCount = filteredValues.Count();
+                if (filteredCount == 1)
+                {
+                    // If there's only one value and it exactly matches, return no valid values
+                    if (filteredValues.First().Equals(this.InvalidValue, StringComparison.OrdinalIgnoreCase))
+                    {
+                        filteredValues = null;
+                    }
+                }
+                else if (filteredCount == 0)
+                {
+                    // If nothing was left after filtering, return the full list
+                    filteredValues = this.ValidValues;
+                }
+
+                return filteredValues;
             }
         }
 

--- a/XForm/XForm/Query/XqlParser.cs
+++ b/XForm/XForm/Query/XqlParser.cs
@@ -557,7 +557,7 @@ namespace XForm.Query
             }
         }
 
-        public bool WasLastTokenInQuery => (_scanner.Current.Type == TokenType.End && _scanner.Current.WhitespacePrefix.Length == 0) || _scanner.Current.Type == TokenType.NextTokenHint;
+        public bool WasLastTokenInQuery => ((_scanner.Current.Type == TokenType.End || _scanner.Current.Type == TokenType.NextTokenHint) && _scanner.Current.WhitespacePrefix.Length == 0);
         public bool HasAnotherPart => _scanner.Current.Type != TokenType.Newline && _scanner.Current.Type != TokenType.End;
         public bool HasAnotherArgument => HasAnotherPart && _scanner.Current.Type != TokenType.CloseParen;
         public Position CurrentPosition => _scanner.Current.Position;

--- a/XForm/XForm/Query/XqlParser.cs
+++ b/XForm/XForm/Query/XqlParser.cs
@@ -15,7 +15,6 @@ using XForm.Extensions;
 using XForm.Functions;
 using XForm.Query.Expression;
 using XForm.Types;
-using XForm.Verbs;
 
 namespace XForm.Query
 {
@@ -33,6 +32,11 @@ namespace XForm.Query
             _scanner = new XqlScanner(xqlQuery);
             _workflow = workflow;
             _currentlyBuilding = new Stack<IUsage>();
+        }
+
+        public void RewindTo(Position position)
+        {
+            _scanner.RewindTo(position);
         }
 
         private static void EnsureLoaded()
@@ -486,10 +490,10 @@ namespace XForm.Query
         {
             ErrorContext context = new ErrorContext();
             context.TableName = _workflow.CurrentTable;
-            context.QueryLineNumber = _scanner.Current.LineNumber;
+            context.QueryLineNumber = _scanner.Current.Position.LineNumber;
             context.Usage = (_currentlyBuilding.Count > 0 ? _currentlyBuilding.Peek().Usage : null);
             context.InvalidValue = _scanner.Current.RawValue;
-            context.InvalidTokenIndex = _scanner.Current.Index;
+            context.InvalidTokenIndex = _scanner.Current.Position.Index;
             context.ErrorMessage = "";
 
             return context;
@@ -556,7 +560,7 @@ namespace XForm.Query
         public bool WasLastTokenInQuery => (_scanner.Current.Type == TokenType.End && _scanner.Current.WhitespacePrefix.Length == 0) || _scanner.Current.Type == TokenType.NextTokenHint;
         public bool HasAnotherPart => _scanner.Current.Type != TokenType.Newline && _scanner.Current.Type != TokenType.End;
         public bool HasAnotherArgument => HasAnotherPart && _scanner.Current.Type != TokenType.CloseParen;
-        public int CurrentLineNumber => _scanner.Current.LineNumber;
+        public Position CurrentPosition => _scanner.Current.Position;
         public string NextTokenText => (HasAnotherPart ? _scanner.Current.Value : "");
     }
 }

--- a/XForm/XForm/Query/XqlScanner.cs
+++ b/XForm/XForm/Query/XqlScanner.cs
@@ -20,6 +20,29 @@ namespace XForm.Query
         NextTokenHint
     }
 
+    public class Position
+    {
+        public int Index { get; set; }
+        public int LineNumber { get; set; }
+        public int LastNewlineIndex { get; set; }
+        public int CharInLine => (Index - LastNewlineIndex);
+
+        public Position(int index, int lineNumber, int lastNewlineIndex)
+        {
+            this.Index = index;
+            this.LineNumber = lineNumber;
+            this.LastNewlineIndex = lastNewlineIndex;
+        }
+
+        public Position(Position other) : this(other.Index, other.LineNumber, other.LastNewlineIndex)
+        { }
+
+        public override string ToString()
+        {
+            return $"({LineNumber}, {CharInLine})";
+        }
+    }
+
     public class Token
     {
         public TokenType Type { get; set; }             // Type of current token
@@ -28,18 +51,18 @@ namespace XForm.Query
         public string WhitespacePrefix { get; set; }    // The whitespace before this token, if any
         public bool IsWrapped { get; set; }             // Whether this token was wrapped (in quotes or braces), and so had an explicit end marker
 
-        public int LineNumber { get; set; }             // The line in the query where this token starts (after whitespace)
-        public int CharInLine { get; set; }             // The character in the query line where this token starts (after whitespace)
-        public int Index { get; set; }                  // The .NET string index where this token starts (after whitespace)
+        public Position Position { get; set; }
 
-        public Token(int currentLineNumber)
+        public Token(Position position)
         {
             this.Type = TokenType.End;
             this.Value = "";
             this.RawValue = "";
             this.WhitespacePrefix = "";
             this.IsWrapped = false;
-            this.LineNumber = currentLineNumber;
+
+            // Make a snapshot of the other position
+            this.Position = new Position(position);
         }
     }
 
@@ -59,9 +82,7 @@ namespace XForm.Query
         private static HashSet<char> s_charactersRequiringEscaping;
 
         private string Text { get; set; }
-        private int CurrentIndex { get; set; }
-        private int LastNewlineIndex { get; set; }
-        private int CurrentLineNumber { get; set; }
+        private Position Position { get; set; }
 
         public Token Current { get; set; }
 
@@ -73,10 +94,16 @@ namespace XForm.Query
         public XqlScanner(string xqlQuery)
         {
             this.Text = xqlQuery;
-            Current = new Token(1) { Type = TokenType.Newline, Index = 0 };
-            LastNewlineIndex = -1;
-            CurrentLineNumber = 1;
+            this.Position = new Position(0, 1, -1);
+            Current = new Token(this.Position) { Type = TokenType.Newline };
             Next();
+        }
+
+        public void RewindTo(Position position)
+        {
+            // Go back to the start of the token and re-read it
+            this.Position = new Position(position);
+            InnerNext();
         }
 
         public bool Next()
@@ -106,22 +133,18 @@ namespace XForm.Query
 
         public bool InnerNext()
         {
-            this.Current = new Token(CurrentLineNumber);
+            string whitespace = ReadWhitespace();
+            this.Current = new Token(this.Position) { WhitespacePrefix = whitespace };
 
-            ReadWhitespace();
+            if (this.Position.Index >= Text.Length) return false;
 
-            this.Current.Index = this.CurrentIndex;
-            this.Current.CharInLine = this.CurrentIndex - this.LastNewlineIndex;
-
-            if (CurrentIndex >= Text.Length) return false;
-
-            char next = Text[CurrentIndex];
+            char next = Text[this.Position.Index];
             if (next == '\r' || next == '\n')
             {
-                CurrentIndex++;
-                if (next == '\r' || Peek() == '\n') CurrentIndex++;
-                this.CurrentLineNumber++;
-                this.LastNewlineIndex = CurrentIndex;
+                this.Position.Index++;
+                if (next == '\r' || Peek() == '\n') this.Position.Index++;
+                this.Position.LineNumber++;
+                this.Position.LastNewlineIndex = this.Position.Index;
                 this.Current.Type = TokenType.Newline;
             }
             else if (next == '?')
@@ -135,12 +158,12 @@ namespace XForm.Query
             }
             else if (next == '(')
             {
-                CurrentIndex++;
+                this.Position.Index++;
                 this.Current.Type = TokenType.OpenParen;
             }
             else if (next == ')')
             {
-                CurrentIndex++;
+                this.Position.Index++;
                 this.Current.Type = TokenType.CloseParen;
             }
             else if (next == '[')
@@ -160,35 +183,31 @@ namespace XForm.Query
             }
 
             // Get the unescaped, un-interpreted value of the current token
-            this.Current.RawValue = this.Text.Substring(this.Current.Index, CurrentIndex - this.Current.Index);
+            this.Current.RawValue = this.Text.Substring(this.Current.Position.Index, this.Position.Index - this.Current.Position.Index);
 
             return true;
         }
 
         private char Peek()
         {
-            if (CurrentIndex < Text.Length) return Text[CurrentIndex];
+            if (this.Position.Index < Text.Length) return Text[this.Position.Index];
             return '\0';
         }
 
-        private void ReadWhitespace()
+        private string ReadWhitespace()
         {
             int whitespaceLength;
-            for (whitespaceLength = 0; CurrentIndex + whitespaceLength < Text.Length; ++whitespaceLength)
+            for (whitespaceLength = 0; this.Position.Index + whitespaceLength < Text.Length; ++whitespaceLength)
             {
-                char current = Text[CurrentIndex + whitespaceLength];
+                char current = Text[this.Position.Index + whitespaceLength];
                 if (current != ' ' && current != '\t' && current != ',') break;
             }
 
-            if (whitespaceLength > 0)
-            {
-                this.Current.WhitespacePrefix = Text.Substring(CurrentIndex, whitespaceLength);
-                this.CurrentIndex += whitespaceLength;
-            }
-            else
-            {
-                this.Current.WhitespacePrefix = String.Empty;
-            }
+            if (whitespaceLength == 0) return string.Empty;
+
+            string whitespace = Text.Substring(this.Position.Index, whitespaceLength);
+            this.Position.Index += whitespaceLength;
+            return whitespace;
         }
 
         private void ParseWrappedValue(char escapeChar)
@@ -196,68 +215,68 @@ namespace XForm.Query
             StringBuilder value = new StringBuilder();
 
             // Consume the opening character
-            CurrentIndex++;
+            this.Position.Index++;
 
             // If we're here, mark the token as wrapped
             this.Current.IsWrapped = true;
 
             // Find the end for unterminated values (the next newline or the end of the query)
-            int end = Text.IndexOf('\n', CurrentIndex);
+            int end = Text.IndexOf('\n', this.Position.Index);
             if (end == -1) end = Text.Length;
             else if (Text[end - 1] == '\r') end--;
 
-            while (CurrentIndex < end)
+            while (this.Position.Index < end)
             {
-                int nextEscape = Text.IndexOf(escapeChar, CurrentIndex);
+                int nextEscape = Text.IndexOf(escapeChar, this.Position.Index);
                 if (nextEscape == -1) break;
 
                 if (Text.Length > (nextEscape + 1) && Text[nextEscape + 1] == escapeChar)
                 {
                     // Escaped Value of Escape Character - append the value so far including one copy and keep searching for the end
-                    value.Append(Text, CurrentIndex, nextEscape - CurrentIndex + 1);
-                    CurrentIndex = nextEscape + 2;
+                    value.Append(Text, this.Position.Index, nextEscape - this.Position.Index + 1);
+                    this.Position.Index = nextEscape + 2;
                 }
                 else
                 {
                     // Value Terminator. Append the value without the terminator and return it
-                    value.Append(Text, CurrentIndex, nextEscape - CurrentIndex);
-                    CurrentIndex = nextEscape + 1;
+                    value.Append(Text, this.Position.Index, nextEscape - this.Position.Index);
+                    this.Position.Index = nextEscape + 1;
                     this.Current.Value = value.ToString();
                     return;
                 }
             }
 
             // If no terminator, treat the value as going to the end of the line. This is so partially typed queries run.
-            value.Append(Text, CurrentIndex, end - CurrentIndex);
-            CurrentIndex = end;
+            value.Append(Text, this.Position.Index, end - this.Position.Index);
+            this.Position.Index = end;
             this.Current.Value = value.ToString();
         }
 
         private void ParseUnwrappedValue()
         {
-            int startIndex = CurrentIndex;
-            while (CurrentIndex < Text.Length)
+            int startIndex = this.Position.Index;
+            while (this.Position.Index < Text.Length)
             {
-                char current = Text[CurrentIndex];
+                char current = Text[this.Position.Index];
                 if (Char.IsWhiteSpace(current) || current == '(' || current == ')' || current == ',') break;
-                CurrentIndex++;
+                this.Position.Index++;
             }
 
             this.Current.IsWrapped = false;
-            this.Current.Value = Text.Substring(startIndex, CurrentIndex - startIndex);
+            this.Current.Value = Text.Substring(startIndex, this.Position.Index - startIndex);
         }
 
         private void ParseUntilNewline()
         {
-            int startIndex = CurrentIndex;
-            while (CurrentIndex < Text.Length)
+            int startIndex = this.Position.Index;
+            while (this.Position.Index < Text.Length)
             {
-                char current = Text[CurrentIndex];
+                char current = Text[this.Position.Index];
                 if (current == '\r' || current == '\n') break;
-                CurrentIndex++;
+                this.Position.Index++;
             }
 
-            this.Current.Value = Text.Substring(startIndex, CurrentIndex - startIndex);
+            this.Current.Value = Text.Substring(startIndex, this.Position.Index - startIndex);
         }
 
         public static string Escape(object value, TokenType type, bool wasUnwrapped = false)

--- a/XForm/XForm/Query/XqlScanner.cs
+++ b/XForm/XForm/Query/XqlScanner.cs
@@ -88,7 +88,7 @@ namespace XForm.Query
 
         static XqlScanner()
         {
-            s_charactersRequiringEscaping = new HashSet<char>(new char[] { ' ', '\t', '"', '[', ']', '(', ')', ',', '?' });
+            s_charactersRequiringEscaping = new HashSet<char>(new char[] { ' ', '\t', '"', '[', ']', '(', ')', ',', '~' });
         }
 
         public XqlScanner(string xqlQuery)
@@ -147,7 +147,7 @@ namespace XForm.Query
                 this.Position.LastNewlineIndex = this.Position.Index;
                 this.Current.Type = TokenType.Newline;
             }
-            else if (next == '?')
+            else if (next == '~')
             {
                 this.Current.Type = TokenType.NextTokenHint;
             }

--- a/XForm/XForm/Types/ByteProvider.cs
+++ b/XForm/XForm/Types/ByteProvider.cs
@@ -95,6 +95,7 @@ namespace XForm.Types
     {
         private Stream _stream;
         private byte[] _buffer;
+        private long _bytesWritten;
 
         public ByteWriter(Stream stream)
         {
@@ -102,6 +103,11 @@ namespace XForm.Types
         }
 
         public Type WritingAsType => typeof(byte);
+
+        public bool CanAppend(XArray xarray)
+        {
+            return (_bytesWritten + xarray.Count) < BinaryTableWriter.ColumnFileSizeLimit;
+        }
 
         public void Append(XArray xarray)
         {
@@ -121,6 +127,7 @@ namespace XForm.Types
             }
 
             _stream.Write((byte[])xarray.Array, xarray.Selector.StartIndexInclusive, xarray.Count);
+            _bytesWritten += xarray.Count;
         }
 
         public void Dispose()

--- a/XForm/XForm/Types/ByteProvider.cs
+++ b/XForm/XForm/Types/ByteProvider.cs
@@ -106,7 +106,7 @@ namespace XForm.Types
 
         public bool CanAppend(XArray xarray)
         {
-            return (_bytesWritten + xarray.Count) < BinaryTableWriter.ColumnFileSizeLimit;
+            return (_bytesWritten + xarray.Count) <= BinaryTableWriter.ColumnFileSizeLimit;
         }
 
         public void Append(XArray xarray)

--- a/XForm/XForm/Types/Comparers/SetComparer.cs
+++ b/XForm/XForm/Types/Comparers/SetComparer.cs
@@ -41,8 +41,13 @@ namespace XForm.Types.Comparers
             Func<XArray> valuesGetter = leftColumn.ValuesGetter();
             if (valuesGetter == null) throw new ArgumentException("ConvertToEnumIndexComparer is only valid for columns implementing Values.");
 
-            // Get all distinct values from the left side and find matches
+            // Get all distinct values from the left side
             XArray left = valuesGetter();
+
+            // If there are no values, return none
+            if (left.Count == 0) return None;
+
+            // Get right side and compare
             XArray right = rightColumn.ValuesGetter()();
             BitVector set = new BitVector(left.Count);
             currentComparer(left, right, set);

--- a/XForm/XForm/Types/ITypeProvider.cs
+++ b/XForm/XForm/Types/ITypeProvider.cs
@@ -12,13 +12,37 @@ namespace XForm.Types
 {
     public interface IColumnReader : IDisposable
     {
+        /// <summary>
+        ///  Row Count in read file.
+        /// </summary>
         int Count { get; }
+
+        /// <summary>
+        ///  Read the rows for the given selector into an XArray.
+        /// </summary>
+        /// <param name="selector">ArraySelector for desired rows.</param>
+        /// <returns>XArray with values for selected rows.</returns>
         XArray Read(ArraySelector selector);
     }
 
     public interface IColumnWriter : IDisposable
     {
+        /// <summary>
+        ///  Type of the values being written.
+        /// </summary>
         Type WritingAsType { get; }
+
+        /// <summary>
+        ///  Check whether the new values can be written within the file size limit for the column.
+        /// </summary>
+        /// <param name="xarray">XArray of values to write</param>
+        /// <returns>True if the new values fit in the file size limit for the column type, False otherwise.</returns>
+        bool CanAppend(XArray xarray);
+
+        /// <summary>
+        ///  Append the provided values to the file.
+        /// </summary>
+        /// <param name="xarray">XArray with current set of values</param>
         void Append(XArray xarray);
     }
 

--- a/XForm/XForm/Types/PrimitiveTypeProvider.cs
+++ b/XForm/XForm/Types/PrimitiveTypeProvider.cs
@@ -158,6 +158,7 @@ namespace XForm.Types
         private int _bytesPerItem;
         private Stream _stream;
         private byte[] _bytesBuffer;
+        private long _bytesWritten;
 
         public PrimitiveArrayWriter(Stream stream)
         {
@@ -167,13 +168,21 @@ namespace XForm.Types
 
         public Type WritingAsType => typeof(T);
 
+        public bool CanAppend(XArray xarray)
+        {
+            // NOTE: Don't cast XArray.Array here; writers which wrap PrimitiveArrayWriter pass XArrays with the right row count
+            // but unrelated values here.
+            return (_bytesWritten + (_bytesPerItem * xarray.Count)) < BinaryTableWriter.ColumnFileSizeLimit;
+        }
+
         public void Append(XArray array)
         {
-            Allocator.AllocateToSize(ref _bytesBuffer, _bytesPerItem * array.Count);
+            int bytesToWrite = _bytesPerItem * array.Count;
+            Allocator.AllocateToSize(ref _bytesBuffer, bytesToWrite);
 
             if (array.Selector.Indices == null && array.Selector.IsSingleValue == false)
             {
-                Buffer.BlockCopy(array.Array, _bytesPerItem * array.Selector.StartIndexInclusive, _bytesBuffer, 0, _bytesPerItem * array.Count);
+                Buffer.BlockCopy(array.Array, _bytesPerItem * array.Selector.StartIndexInclusive, _bytesBuffer, 0, bytesToWrite);
             }
             else
             {
@@ -184,7 +193,8 @@ namespace XForm.Types
                 }
             }
 
-            _stream.Write(_bytesBuffer, 0, _bytesPerItem * array.Count);
+            _stream.Write(_bytesBuffer, 0, bytesToWrite);
+            _bytesWritten += bytesToWrite;
         }
 
         public void Dispose()

--- a/XForm/XForm/Types/PrimitiveTypeProvider.cs
+++ b/XForm/XForm/Types/PrimitiveTypeProvider.cs
@@ -172,7 +172,7 @@ namespace XForm.Types
         {
             // NOTE: Don't cast XArray.Array here; writers which wrap PrimitiveArrayWriter pass XArrays with the right row count
             // but unrelated values here.
-            return (_bytesWritten + (_bytesPerItem * xarray.Count)) < BinaryTableWriter.ColumnFileSizeLimit;
+            return (_bytesWritten + (_bytesPerItem * xarray.Count)) <= BinaryTableWriter.ColumnFileSizeLimit;
         }
 
         public void Append(XArray array)

--- a/XForm/XForm/Types/String8TypeProvider.cs
+++ b/XForm/XForm/Types/String8TypeProvider.cs
@@ -171,6 +171,9 @@ namespace XForm.Types
             _streamProvider = streamProvider;
             _bytesReader = TypeProviderFactory.TryGetColumnReader(streamProvider, typeof(byte), Path.Combine(columnPath, "V.s.bin"), option, typeof(String8ColumnReader));
             _positionsReader = TypeProviderFactory.TryGetColumnReader(streamProvider, typeof(int), Path.Combine(columnPath, "Vp.i32.bin"), option, typeof(String8ColumnReader));
+
+            if (_bytesReader == null) throw new IOException($"No value bytes found in {columnPath}.");
+            if (_positionsReader == null) throw new IOException($"No value positions found in {columnPath}.");
         }
 
         public int Count => _positionsReader.Count;
@@ -306,7 +309,7 @@ namespace XForm.Types
                 bytesThisTime += value.Length;
             }
 
-            return (_position + bytesThisTime) < BinaryTableWriter.ColumnFileSizeLimit;
+            return (_position + bytesThisTime) <= BinaryTableWriter.ColumnFileSizeLimit;
         }
 
         public void Append(XArray xarray)

--- a/XForm/XForm/Types/String8TypeProvider.cs
+++ b/XForm/XForm/Types/String8TypeProvider.cs
@@ -294,6 +294,21 @@ namespace XForm.Types
 
         public Type WritingAsType => typeof(String8);
 
+        public bool CanAppend(XArray xarray)
+        {
+            if (!_positionsWriter.CanAppend(xarray)) return false;
+
+            long bytesThisTime = 0;
+            String8[] array = (String8[])xarray.Array;
+            for (int i = 0; i < xarray.Count; ++i)
+            {
+                String8 value = array[xarray.Index(i)];
+                bytesThisTime += value.Length;
+            }
+
+            return (_position + bytesThisTime) < BinaryTableWriter.ColumnFileSizeLimit;
+        }
+
         public void Append(XArray xarray)
         {
             Allocator.AllocateToSize(ref _positionsBuffer, xarray.Count);

--- a/XForm/XForm/Verbs/Cast.cs
+++ b/XForm/XForm/Verbs/Cast.cs
@@ -19,7 +19,8 @@ namespace XForm.Verbs
 
         public IXTable Build(IXTable source, XDatabaseContext context)
         {
-            return new Cast(source, _castFunctionBuilder.Build(source, context));
+            // Cast can be evaluated in parallel, so keep parallel
+            return source.WrapParallel(context.Parser, (part) => new Cast(part, _castFunctionBuilder.Build(part, context)));
         }
     }
 

--- a/XForm/XForm/Verbs/Join.cs
+++ b/XForm/XForm/Verbs/Join.cs
@@ -21,6 +21,8 @@ namespace XForm.Verbs
 
         public IXTable Build(IXTable source, XDatabaseContext context)
         {
+            // NOTE: Not parallel to build only one copy of the JoinTo table.
+
             string sourceColumnName = context.Parser.NextColumnName(source);
             IXTable joinToSource = context.Parser.NextTableSource();
             string joinToColumn = context.Parser.NextColumnName(joinToSource);

--- a/XForm/XForm/Verbs/Read.cs
+++ b/XForm/XForm/Verbs/Read.cs
@@ -76,7 +76,7 @@ namespace XForm.Verbs
             // Return the source(s) found
             if (sources.Count == 1) return sources[0];
 
-            return new ConcatenatingReader(sources);
+            return new ConcatenatedTable(sources);
         }
     }
 }

--- a/XForm/XForm/Verbs/Read.cs
+++ b/XForm/XForm/Verbs/Read.cs
@@ -74,9 +74,7 @@ namespace XForm.Verbs
             historicalContext.Pop(context);
 
             // Return the source(s) found
-            if (sources.Count == 1) return sources[0];
-
-            return new ConcatenatedTable(sources);
+            return ConcatenatedTable.Build(sources);
         }
     }
 }

--- a/XForm/XForm/Verbs/Remove.cs
+++ b/XForm/XForm/Verbs/Remove.cs
@@ -24,7 +24,8 @@ namespace XForm.Verbs
                 columnNames.Add(context.Parser.NextColumnName(source));
             }
 
-            return new Remove(source, columnNames);
+            // Remove can be evaluated in parallel, so keep parallel
+            return source.WrapParallel(context.Parser, (part) => new Remove(part, columnNames));
         }
     }
 

--- a/XForm/XForm/Verbs/Rename.cs
+++ b/XForm/XForm/Verbs/Rename.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 
 using XForm.Columns;
 using XForm.Data;
+using XForm.Extensions;
 using XForm.Query;
 
 namespace XForm.Verbs
@@ -23,7 +24,8 @@ namespace XForm.Verbs
                 columnNameMappings[context.Parser.NextColumnName(source)] = context.Parser.NextOutputColumnName(source);
             }
 
-            return new Rename(source, columnNameMappings);
+            // Rename can be evaluated in parallel, so keep parallel
+            return source.WrapParallel(context.Parser, (part) => new Rename(part, columnNameMappings));
         }
     }
 

--- a/XForm/XForm/Verbs/Set.cs
+++ b/XForm/XForm/Verbs/Set.cs
@@ -17,9 +17,13 @@ namespace XForm.Verbs
 
         public IXTable Build(IXTable source, XDatabaseContext context)
         {
-            return new Set(source,
-                context.Parser.NextOutputColumnName(source),
-                context.Parser.NextColumn(source, context));
+            // Set can be evaluated in parallel, so keep parallel
+            return source.WrapParallel(context.Parser, (part) =>
+                new Set(
+                    part,
+                    context.Parser.NextOutputColumnName(part),
+                    context.Parser.NextColumn(part, context))
+            );
         }
     }
 

--- a/XForm/XForm/Verbs/Where.cs
+++ b/XForm/XForm/Verbs/Where.cs
@@ -21,7 +21,8 @@ namespace XForm.Verbs
 
         public IXTable Build(IXTable source, XDatabaseContext context)
         {
-            return new Where(source, context.Parser.NextExpression(source, context));
+            // Where can be evaluated in parallel, so keep parallel
+            return source.WrapParallel(context.Parser, (part) => new Where(part, context.Parser.NextExpression(part, context)));
         }
     }
 

--- a/XForm/XForm/WorkflowRunner.cs
+++ b/XForm/XForm/WorkflowRunner.cs
@@ -212,7 +212,7 @@ namespace XForm
             // Return the source (if a single) or concatenated group (if multiple parts)
             if (sources.Count == 1) return sources[0];
 
-            return new ConcatenatingReader(sources);
+            return new ConcatenatedTable(sources);
         }
 
         private bool IsOutOfDate(DateTime outputWhenModifiedUtc, DateTime inputsWhenModifiedUtc)

--- a/XForm/XForm/XForm.csproj
+++ b/XForm/XForm/XForm.csproj
@@ -169,7 +169,7 @@
     <Compile Include="Functions\String\ToUpper.cs" />
     <Compile Include="HttpService.cs" />
     <Compile Include="InteractiveRunner.cs" />
-    <Compile Include="IO\ConcatenatingReader.cs" />
+    <Compile Include="Data\ConcatenatedTable.cs" />
     <Compile Include="IO\DirectoryIO.cs" />
     <Compile Include="IO\StreamProvider\DeflateStreamProvider.cs" />
     <Compile Include="IO\StreamProvider\IStreamProvider.cs" />


### PR DESCRIPTION
Added multi-partition table reading and writing.
BinaryTableWriter detects when partition is full and starts a new one.
Verbs which can support running in parallel have been parallelized (where their output rows, when concatenated, produce the same results as if concatenating the input rows and running serially) .
XqlParser redesign to allow "rewinding" parsing for easy parallel pipeline parsing.
XqlParser IntelliSense improvements. 