### PR TITLE
Add PDB forging logic and exe as 'SymbolForge'

### DIFF
--- a/Elfie/Elfie.sln
+++ b/Elfie/Elfie.sln
@@ -30,6 +30,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xsv", "Xsv\Xsv.csproj", "{7
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xsv.Test", "Xsv.Test\Xsv.Test.csproj", "{8A711BBB-5B69-4BAF-86A2-FB25397794B9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SymbolForge", "SymbolForge\SymbolForge.csproj", "{BD3B23A9-9086-49BD-9C75-9554D56248BE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -172,6 +174,18 @@ Global
 		{8A711BBB-5B69-4BAF-86A2-FB25397794B9}.Release|x64.Build.0 = Release|Any CPU
 		{8A711BBB-5B69-4BAF-86A2-FB25397794B9}.Release|x86.ActiveCfg = Release|Any CPU
 		{8A711BBB-5B69-4BAF-86A2-FB25397794B9}.Release|x86.Build.0 = Release|Any CPU
+		{BD3B23A9-9086-49BD-9C75-9554D56248BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD3B23A9-9086-49BD-9C75-9554D56248BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD3B23A9-9086-49BD-9C75-9554D56248BE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BD3B23A9-9086-49BD-9C75-9554D56248BE}.Debug|x64.Build.0 = Debug|Any CPU
+		{BD3B23A9-9086-49BD-9C75-9554D56248BE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BD3B23A9-9086-49BD-9C75-9554D56248BE}.Debug|x86.Build.0 = Debug|Any CPU
+		{BD3B23A9-9086-49BD-9C75-9554D56248BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD3B23A9-9086-49BD-9C75-9554D56248BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD3B23A9-9086-49BD-9C75-9554D56248BE}.Release|x64.ActiveCfg = Release|Any CPU
+		{BD3B23A9-9086-49BD-9C75-9554D56248BE}.Release|x64.Build.0 = Release|Any CPU
+		{BD3B23A9-9086-49BD-9C75-9554D56248BE}.Release|x86.ActiveCfg = Release|Any CPU
+		{BD3B23A9-9086-49BD-9C75-9554D56248BE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Elfie/SymbolForge/Program.cs
+++ b/Elfie/SymbolForge/Program.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.CodeAnalysis.Elfie.Indexer;
+using System;
+using System.Diagnostics;
+
+namespace SymbolForge
+{
+    /// <summary>
+    ///  SymbolForge changes a PDB so that Visual Studio considers it a match for a given DLL.
+    ///  
+    ///  This will only be useful if the PDB was built from the same sources with the same compiler.
+    ///  DLLs have a GUID and 'Age' burned into them which has to match in the PDB.
+    ///  This code reads the GUID and Age and writes those values into the desired PDB.
+    /// </summary>
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            if(args.Length != 2)
+            {
+                Console.WriteLine("Usage: SymbolForge <DllPath> <PdbPath>");
+                Console.WriteLine("SymbolForge writes the GUID and Age from a DLL into a PDB so that VS considers them matching.");
+                return -2;
+            }
+
+            try
+            {
+                string dllPath = args[0];
+                string pdbPath = args[1];
+
+                RsDsSignature signature = Assembly.ReadRsDsSignature(dllPath);
+                Console.WriteLine($"{dllPath} signature: {signature}");
+
+                Assembly.WriteRsDsSignature(pdbPath, signature);
+                Console.WriteLine($"Done. {pdbPath} signature set to {signature}.");
+                return 0;
+            }
+            catch(Exception ex) when (!Debugger.IsAttached)
+            {
+                Console.WriteLine($"ERROR: {ex}");
+                return -1;
+            }
+        }
+    }
+}

--- a/Elfie/SymbolForge/Properties/AssemblyInfo.cs
+++ b/Elfie/SymbolForge/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SymbolForge")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SymbolForge")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("bd3b23a9-9086-49bd-9c75-9554d56248be")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Elfie/SymbolForge/SymbolForge.csproj
+++ b/Elfie/SymbolForge/SymbolForge.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BD3B23A9-9086-49BD-9C75-9554D56248BE}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>SymbolForge</RootNamespace>
+    <AssemblyName>SymbolForge</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeAnalysis.Elfie, Version=0.10.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Elfie.0.10.6\lib\net46\Microsoft.CodeAnalysis.Elfie.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Elfie.Indexer\Elfie.Api.Indexer.csproj">
+      <Project>{48c0034d-8531-4b72-95d8-50250bf7af4f}</Project>
+      <Name>Elfie.Api.Indexer</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Elfie/SymbolForge/app.config
+++ b/Elfie/SymbolForge/app.config
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.FileVersionInfo" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Composition.AttributedModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Composition.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Thread" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Composition.TypedParts" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Composition.Hosting" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Elfie/SymbolForge/packages.config
+++ b/Elfie/SymbolForge/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis.Elfie" version="0.10.6" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
+</packages>


### PR DESCRIPTION
  - In the DLL, there's a marker 'RSDS' followed by a GUID and uint which have to match the PDB. These can be read by the PEReader.
  - In the PDB, there are two copies of the uint for 20000404, the file version of the PDB (2000-04-04), followed by a file time (apparently), and then the Age and GUID. If both are replaced, VS considers the PDB a match.

This only works if the DLLs were built from the same sources by the same compiler version. Try stepping into the source code with the real binary and forged PDB to assess the match quality.