### PR TITLE
XForm: June Work

### DIFF
--- a/Elfie/Elfie/Serialization/TabularFactory.cs
+++ b/Elfie/Elfie/Serialization/TabularFactory.cs
@@ -88,7 +88,18 @@ namespace Microsoft.CodeAnalysis.Elfie.Serialization
 
         private static Func<U, T> GetConstructorFunc<T, U>(string keyName, string assemblyName, string typeName)
         {
-            Assembly asm = Assembly.Load(assemblyName);
+            Assembly asm;
+            if (assemblyName.Contains("\\"))
+            {
+                string exePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                string expectedPath = Path.Combine(exePath, assemblyName + ".dll");
+                asm = Assembly.LoadFrom(expectedPath);
+            }
+            else
+            {
+                asm = Assembly.Load(assemblyName);
+            }
+
             Type readerType = asm.GetType(typeName);
             if (readerType == null)
             {

--- a/XForm/XForm.Test/Verbs/VerbsTests.cs
+++ b/XForm/XForm.Test/Verbs/VerbsTests.cs
@@ -223,5 +223,20 @@ namespace XForm.Test.Query
 
             return values;
         }
+
+        [TestMethod]
+        public void Verb_Skip()
+        {
+            // Verify skipping the first 100 rows of 0-1000 produces 100-1000
+            IXTable expected = TableTestHarness.DatabaseContext.FromArrays(900)
+                .WithColumn("Value", Enumerable.Range(100, 900).ToArray<int>());
+
+            IXTable actual = TableTestHarness.DatabaseContext.FromArrays(1000)
+                .WithColumn("Value", Enumerable.Range(0, 1000).ToArray<int>())
+                .Query(@"
+                    skip 100", TableTestHarness.DatabaseContext);
+
+            TableTestHarness.AssertAreEqual(expected, actual, 25);
+        }
     }
 }

--- a/XForm/XForm.Web/shared.jsx
+++ b/XForm/XForm.Web/shared.jsx
@@ -6,6 +6,23 @@ window.encodeParams = function(params) {
         .map(k => `${k}=${encodeURIComponent(params[k])}`).join('&')
 }
 
+// Build an object with a property for each querystring parameter
+window.getQueryStringParameters = () => {
+    var urlParameters = window.location.search.substring(1);
+    var parameterParts = urlParameters.split("&");
+
+    var result = {};
+
+    for (var i = 0; i < parameterParts.length; ++i) {
+        if (!parameterParts[i]) continue;
+        var parameterAndValue = parameterParts[i].split("=");
+        if (parameterAndValue.length != 2) continue;
+        result[decodeURIComponent(parameterAndValue[0]).toLowerCase()] = decodeURIComponent(parameterAndValue[1]);
+    }
+
+    return result;
+}
+
 window.xhr = (path, paramObj) => {
     return new Promise((resolve, reject) => {
         const xhr = new XMLHttpRequest();

--- a/XForm/XForm/Accessory/PerformanceComparisons.cs
+++ b/XForm/XForm/Accessory/PerformanceComparisons.cs
@@ -3,9 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
-
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Elfie.Diagnostics;
+using Microsoft.CodeAnalysis.Elfie.Extensions;
 using Microsoft.CodeAnalysis.Elfie.Serialization;
 
 using XForm.Core;
@@ -46,7 +50,18 @@ namespace XForm
 
         public void Run()
         {
-            Current();
+            //Current();
+
+            // 350MB/s, 4GB/s RAM cached
+            //DirectRead(@"C:\Download\XFormProduction\Table\HugeSample\Full\2018.06.07 00.00.00Z\0\Segment\V.u16.bin", 20480 * 2);
+
+            // ~380MB/s, 4GB/s RAM cached
+            //ReadSet(@"C:\Download\XFormProduction\Table\HugeSample\Full\2018.06.07 00.00.00Z", @"Segment\V.u16.bin", 20480 * 2);
+
+            // ~450MB/s, 4GB/s RAM cached
+            //ReadSet(@"C:\Download\XFormProduction\Table\HugeSample\Full\2018.06.07 00.00.00Z", @"WasEncrypted\VR.u8.bin", 10 * 1024 * 1024);
+
+            ReadSetParallel(@"C:\Download\XFormProduction\Table\HugeSample\Full\2018.06.07 00.00.00Z", @"Status\VR.u8.bin", 10 * 1024 * 1024);
 
             //WhereUShortUnderConstant();
             //WhereUShortEqualsUshort();
@@ -447,6 +462,55 @@ namespace XForm
                     writer.NextRow();
                 }
             }
+        }
+
+        private static void ReadSet(string tablePath, string filePathPerPartition, int bytesPerRead)
+        {
+            long totalRead = 0;
+
+            using (new TraceWatch($@"Reading {tablePath}\*\{filePathPerPartition}..."))
+            {
+                foreach (string partition in Directory.GetDirectories(tablePath))
+                {
+                    totalRead += DirectRead(Path.Combine(partition, filePathPerPartition), bytesPerRead);
+                }
+            }
+
+            Trace.WriteLine($"Done. Read {totalRead.SizeString()}.");
+        }
+
+        private static void ReadSetParallel(string tablePath, string filePathPerPartition, int bytesPerRead)
+        {
+            long totalRead = 0;
+
+            using (new TraceWatch($@"Reading {tablePath}\*\{filePathPerPartition}..."))
+            {
+                Parallel.ForEach(Directory.GetDirectories(tablePath), (partition) =>
+                {
+                    long setRead = DirectRead(Path.Combine(partition, filePathPerPartition), bytesPerRead);
+                    Interlocked.Add(ref totalRead, setRead);
+                });
+            }
+
+            Trace.WriteLine($"Done. Read {totalRead.SizeString()}.");
+        }
+
+        private static long DirectRead(string filePath, int bytesPerRead)
+        {
+            byte[] buffer = new byte[bytesPerRead];
+            long totalRead = 0;
+            
+            using (FileStream stream = File.OpenRead(filePath))
+            {
+                while(true)
+                {
+                    int bytesRead = stream.Read(buffer, 0, bytesPerRead);
+                    totalRead += bytesRead;
+                    if (bytesRead < bytesPerRead) break;
+                }
+            }
+
+            return totalRead;
         }
     }
 }

--- a/XForm/XForm/Extensions/StreamProviderExtensions.cs
+++ b/XForm/XForm/Extensions/StreamProviderExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Threading;
 using XForm.IO;
@@ -23,6 +22,21 @@ namespace XForm.Extensions
         public static bool Exists(this IStreamProvider streamProvider, string logicalPath)
         {
             return streamProvider.Attributes(logicalPath).Exists;
+        }
+
+        public static bool UncachedExists(this IStreamProvider streamProvider, string logicalPath)
+        {
+            try
+            {
+                using (Stream stream = streamProvider.OpenRead(logicalPath))
+                {
+                    return true;
+                }
+            }
+            catch(IOException)
+            { }
+
+            return false;
         }
 
         public static string Path(this IStreamProvider streamProvider, LocationType type, string tableName, string extension)

--- a/XForm/XForm/Extensions/StreamProviderExtensions.cs
+++ b/XForm/XForm/Extensions/StreamProviderExtensions.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-
+using System.Threading;
 using XForm.IO;
 using XForm.IO.StreamProvider;
 
@@ -87,11 +87,11 @@ namespace XForm.Extensions
                         if (reallyDelete)
                         {
                             // Delete the source
-                            streamProvider.Delete(version.Path);
+                            streamProvider.DeleteWithRetries(version.Path);
                             version.LocationType = LocationType.Table;
 
                             // Delete the matching table, if found
-                            streamProvider.Delete(version.Path);
+                            streamProvider.DeleteWithRetries(version.Path);
                         }
                     }
                 }
@@ -109,10 +109,31 @@ namespace XForm.Extensions
                         countLeft--;
 
                         Trace.WriteLine($"DELETE {version.Path}");
-                        if (reallyDelete) streamProvider.Delete(version.Path);
+                        if (reallyDelete) streamProvider.DeleteWithRetries(version.Path);
                     }
                 }
             }
+        }
+
+        public static void DeleteWithRetries(this IStreamProvider streamProvider, string logicalPath, int tryCount = 3)
+        {
+            Exception lastException = null;
+
+            for(int i = 0; i < tryCount; ++i)
+            {
+                try
+                {
+                    streamProvider.Delete(logicalPath);
+                    return;
+                }
+                catch(Exception ex)
+                {
+                    lastException = ex;
+                    Thread.Sleep(2500);
+                }
+            }
+
+            throw new TimeoutException($"Timed out trying to delete '{logicalPath}' after {tryCount:n0} tries.", lastException);
         }
 
         public static bool ContainsTable(this IStreamProvider streamProvider, string tableName)

--- a/XForm/XForm/Extensions/XTableExtensions.cs
+++ b/XForm/XForm/Extensions/XTableExtensions.cs
@@ -24,7 +24,15 @@ namespace XForm.Extensions
 
     public static class XTableExtensions
     {
-        public const int DefaultBatchSize = 10240;
+        /// <summary>
+        ///  Number of rows to read on each Next() call, if not overridden by caller
+        /// </summary>
+        /// <remarks>
+        ///  For normal scale tables, performance improved up to 10,240 rows and then flattened out.
+        ///  For huge tables, disk I/O seems better for larger batch sizes.
+        ///  The batch size determines the memory use, though usually individual rows aren't especially large.
+        /// </remarks>
+        public const int DefaultBatchSize = 20480; // 10240;
 
         #region Next Overloads
         /// <summary>

--- a/XForm/XForm/HttpService.cs
+++ b/XForm/XForm/HttpService.cs
@@ -278,12 +278,22 @@ namespace XForm
             toStream = new BufferedStream(toStream, 64 * 1024);
 
             format = format.ToLowerInvariant();
-            string sampleOutputFileName = $"Result.{format}";
+            string fileExtension = format;
+
+            // Allow Elfie 'hint' extensions like ~Hint~csv
+            if (format.StartsWith("~"))
+            {
+                int second = format.IndexOf('~', 1);
+                fileExtension = format.Substring(second + 1);
+            }
+
             if(format != "json")
             {
                 // Add a 'download this' header to all formats except JSON
-                response.AddHeader("Content-Disposition", $"attachment; filename=\"{sampleOutputFileName}\"");
-                return TabularFactory.BuildWriter(toStream, sampleOutputFileName);
+                response.AddHeader("Content-Disposition", $"attachment; filename=\"Result.{fileExtension}\"");
+
+                // Build the writer using the original format (with any hint)
+                return TabularFactory.BuildWriter(toStream, $"Result.{format}");
             }
             else
             {

--- a/XForm/XForm/IO/ItemVersions.cs
+++ b/XForm/XForm/IO/ItemVersions.cs
@@ -46,9 +46,16 @@ namespace XForm.IO
             return this.Versions.LastOrDefault((v) => (v.CrawlType == crawlType && v.AsOfDate <= cutoff));
         }
 
-        public IEnumerable<ItemVersion> VersionsInRange(CrawlType crawlType, DateTime startDateTime, DateTime asOfDateTime)
+        public IEnumerable<ItemVersion> VersionsInRange(CrawlType crawlType, DateTime startDateTime, DateTime asOfDateTime, bool startInclusive = false)
         {
-            return this.Versions.Where((v) => (v.CrawlType == crawlType && v.AsOfDate >= startDateTime && v.AsOfDate <= asOfDateTime));
+            if (startInclusive)
+            {
+                return this.Versions.Where((v) => (v.CrawlType == crawlType && v.AsOfDate >= startDateTime && v.AsOfDate <= asOfDateTime));
+            }
+            else
+            {
+                return this.Versions.Where((v) => (v.CrawlType == crawlType && v.AsOfDate > startDateTime && v.AsOfDate <= asOfDateTime));
+            }
         }
     }
 

--- a/XForm/XForm/IO/StreamProvider/LocalFileStreamProvider.cs
+++ b/XForm/XForm/IO/StreamProvider/LocalFileStreamProvider.cs
@@ -74,7 +74,7 @@ namespace XForm.IO.StreamProvider
 
         public Stream OpenRead(string logicalPath)
         {
-            return new FileStream(PathCombineSandbox(logicalPath), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            return new FileStream(PathCombineSandbox(logicalPath), FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
         }
 
         public Stream OpenWrite(string logicalPath)

--- a/XForm/XForm/IO/TableMetadata.cs
+++ b/XForm/XForm/IO/TableMetadata.cs
@@ -154,5 +154,10 @@ namespace XForm.IO
 
             return metadata;
         }
+
+        public static bool UncachedExists(IStreamProvider streamProvider, string tableRootPath)
+        {
+            return streamProvider.UncachedExists(Path.Combine(tableRootPath, MetadataFileName));
+        }
     }
 }

--- a/XForm/XForm/Verbs/Skip.cs
+++ b/XForm/XForm/Verbs/Skip.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+using XForm.Data;
+using XForm.Query;
+
+namespace XForm.Verbs
+{
+    internal class SkipCommandBuilder : IVerbBuilder
+    {
+        public string Verb => "skip";
+        public string Usage => "skip {RowCount}";
+
+        public IXTable Build(IXTable source, XDatabaseContext context)
+        {
+            int countToSkip = context.Parser.NextInteger();
+            return new Skip(source, countToSkip);
+        }
+    }
+
+    /// <summary>
+    ///  'Skip' skips the first [count] rows from the source.
+    ///  Skip and Limit can be used to do paging, but the service must re-run the query each time.
+    /// </summary>
+    /// <remarks>
+    ///  Ideal paging would be by identifying the source table RowId which was last returned and seeking past it to start.
+    ///  When 'Order By' is available, a Where clause to skip already returned rows would be more efficient.
+    /// </remarks>
+    public class Skip : XTableWrapper
+    {
+        private int _countToSkip;
+        private int _rowCountSkipped;
+
+        public Skip(IXTable source, int countToSkip) : base(source)
+        {
+            _countToSkip = countToSkip;
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            _rowCountSkipped = 0;
+        }
+
+        public override int Next(int desiredCount, CancellationToken cancellationToken)
+        {
+            // Skip the desired number of rows
+            while(_countToSkip > _rowCountSkipped)
+            {
+                int rowsToRequest = Math.Min(desiredCount, _countToSkip - _rowCountSkipped);
+                
+                int rowsReturned = _source.Next(rowsToRequest, cancellationToken);
+                if (rowsReturned == 0) return 0;
+
+                _rowCountSkipped += rowsReturned;
+            }
+
+            // Then, just pass through
+            return _source.Next(desiredCount, cancellationToken);
+        }
+    }
+}

--- a/XForm/XForm/XForm.csproj
+++ b/XForm/XForm/XForm.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Verbs\Cast.cs" />
     <Compile Include="Verbs\Choose.cs" />
     <Compile Include="Verbs\GroupBy.cs" />
+    <Compile Include="Verbs\Skip.cs" />
     <Compile Include="Verbs\Peek.cs" />
     <Compile Include="Verbs\Rename.cs" />
     <Compile Include="Verbs\Set.cs" />


### PR DESCRIPTION
- Allow Elfie extensions in subfolders.
- Download: Allow Elfie 'hints' for multiple serializers for the same file extension.
- Add 'Skip' verb for paging.
- Add website missing method.
- Direct I/O performance tests.
- Improve file locking and detect and rebuild tables in cache but deleted on disk.